### PR TITLE
fix: enhance Codex API initialization and key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **✨ Quick Links**: [Codex Support](#-codex-support-v300-new) | [BMad Workflow](#-bmad-workflow-v27-new-feature) | [Spec Workflow](#-spec-workflow-v2124-new-feature) | [Open Web Search](#-open-web-search-v2129-new-feature) | [CCR Router](#-ccr-claude-code-router-support-v28-enhanced) | [CCometixLine](#-ccometixline-support-status-bar-tool-v299-new) | [Output Styles](#-ai-output-styles-v212-new-feature)
 
-> Zero-config, one-click setup for Claude Code with bilingual support, intelligent agent system and personalized AI assistant
+> Zero-config, one-click setup for Claude Code & Codex with bilingual support, intelligent agent system and personalized AI assistant
 
 ![Rendering](./src/assets/screenshot-en.webp)
 

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -12,7 +12,7 @@
 
 **✨ クイックリンク**: [Codexサポート](#-codexサポートv300新機能) | [BMadワークフロー](#-bmadワークフローv27新機能) | [Specワークフロー](#-specワークフローv2124新機能) | [Open Web Search](#-open-web-searchv2129新機能) | [CCRルーター](#-ccr-claude-code-router-サポートv28強化版) | [CCometixLine](#-ccometixlineサポートステータスバーツールv299新機能) | [出力スタイル](#-ai出力スタイルv212新機能)
 
-> ゼロ設定、ワンクリックでClaude Code環境セットアップ - 多言語設定、インテリジェントプロキシシステム、パーソナライズされたAIアシスタント対応
+> ゼロ設定、ワンクリックで Claude Code & Codex 環境セットアップ - 多言語設定、インテリジェントプロキシシステム、パーソナライズされたAIアシスタント対応
 
 ![スクリーンショット](./src/assets/screenshot-en.webp)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -12,7 +12,7 @@
 
 **✨ 快速导航**: [Codex 支持](#-codex-支持v300-新增) | [BMad 工作流](#-bmad-工作流v27-新功能) | [Spec 工作流](#-spec-工作流v2124-新功能) | [开放网页搜索](#-开放网页搜索v2129-新功能) | [CCR 代理](#-ccr-claude-code-router-支持v28-增强版) | [CCometixLine](#-ccometixline-支持状态栏工具v299-新增) | [输出风格](#-ai-输出风格v212-新功能)
 
-> 零配置，一键搞定 Claude Code 环境设置 - 支持中英文双语配置、智能代理系统和个性化 AI 助手
+> 零配置，一键搞定 Claude Code & Codex 环境设置 - 支持中英文双语配置、智能代理系统和个性化 AI 助手
 
 ![效果图](./src/assets/screenshot.webp)
 

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -853,6 +853,7 @@ function createApiConfigChoices(providers: CodexProvider[], currentProvider?: st
 export async function configureCodexApi(): Promise<void> {
   ensureI18nInitialized()
   const existingConfig = readCodexConfig()
+  const existingAuth = readJsonConfig<Record<string, string | null>>(CODEX_AUTH_FILE, { defaultValue: {} }) || {}
 
   // Check if there are existing providers for switch option
   const hasProviders = existingConfig?.providers && existingConfig.providers.length > 0
@@ -1063,6 +1064,14 @@ export async function configureCodexApi(): Promise<void> {
     choices: addNumbersToChoices(toProvidersList(providers)),
     default: existingConfig?.modelProvider || providers[0].id,
   }])
+
+  const selectedProvider = providers.find(provider => provider.id === defaultProvider)
+  if (selectedProvider) {
+    const envKey = selectedProvider.envKey
+    const defaultApiKey = authEntries[envKey] ?? existingAuth[envKey] ?? null
+    if (defaultApiKey)
+      authEntries.OPENAI_API_KEY = defaultApiKey
+  }
 
   writeCodexConfig({
     model: existingConfig?.model || null,

--- a/tests/unit/utils/code-tools/codex.test.ts
+++ b/tests/unit/utils/code-tools/codex.test.ts
@@ -269,7 +269,7 @@ describe('codex code tool utilities', () => {
     const jsonConfigModule = await import('../../../../src/utils/json-config')
     expect(jsonConfigModule.writeJsonConfig).toHaveBeenCalledWith(
       '/home/test/.codex/auth.json',
-      { PACKYCODE_API_KEY: 'secret' },
+      { PACKYCODE_API_KEY: 'secret', OPENAI_API_KEY: 'secret' },
       { pretty: true },
     )
 


### PR DESCRIPTION
## Summary

* Fix Codex API initialization issue by improving API key handling logic
* Update README documentation to reflect Codex support across all language versions
* Correct test expectations to match enhanced functionality

## Changes Made

### 🔧 Code Improvements
- **Enhanced API Key Handling**: Modified `configureCodexApi()` to properly read existing auth configuration and set default API keys
- **Improved Provider Selection**: Added logic to automatically set `OPENAI_API_KEY` when selecting a provider with existing authentication

### 📝 Documentation Updates  
- **Multi-language README**: Updated English, Chinese, and Japanese README files to include "& Codex" in project descriptions
- **Consistent Messaging**: Ensures all documentation reflects the dual Claude Code & Codex support

### ✅ Test Updates
- **Test Alignment**: Updated test expectations in `codex.test.ts` to match the enhanced API key handling behavior
- **Validation Coverage**: Ensures tests properly validate the new `OPENAI_API_KEY` assignment logic

## Technical Details

The main enhancement in `src/utils/code-tools/codex.ts:1068-1074` adds intelligent API key resolution:

```typescript
const selectedProvider = providers.find(provider => provider.id === defaultProvider)
if (selectedProvider) {
  const envKey = selectedProvider.envKey
  const defaultApiKey = authEntries[envKey] ?? existingAuth[envKey] ?? null
  if (defaultApiKey)
    authEntries.OPENAI_API_KEY = defaultApiKey
}
```

This ensures that when a provider is selected, the system automatically populates the `OPENAI_API_KEY` from existing authentication configuration, improving the user experience and preventing configuration gaps.

## Test Plan

- [x] Verify Codex API configuration works with existing authentication
- [x] Confirm README updates are consistent across all language versions  
- [x] Validate test coverage matches new functionality
- [x] Test API key resolution for different provider scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)