### PR TITLE
feat(docs): update sponsor information in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,7 +830,8 @@ A huge thank you to all our sponsors for their generous support!
 - \*\*康 (first KFC sponsor🍗)
 - \*东 (first coffee sponsor☕️)
 - 炼\*3 (first Termux user sponsor📱)
-- 16°C coffee (My best friend🤪, offered Claude Code max $200 package)
+- [chamo101](https://github.com/chamo101) (first GitHub issue sponsor 🎉)
+- 16°C coffee (My best friend🤪, offered ChatGPT Pro $200 package)
 
 ## 📄 License
 

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -706,7 +706,8 @@ ZCFはAndroid Termux環境での実行をサポート：
 - \*\*康（最初のKFCスポンサー🍗）
 - \*东（最初のコーヒースポンサー☕️）
 - 炼\*3（最初のTermuxユーザースポンサー📱）
-- 16°C咖啡（私の親友 🤪、Claude Code max $200プランを提供）
+- [chamo101](https://github.com/chamo101)（最初のGitHub issue ユーザースポンサー🎉）
+- 16°C咖啡（私の親友 🤪、ChatGPT Pro $200プランを提供）
 
 ## 📄 ライセンス
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -838,7 +838,8 @@ ZCF 现已支持在 Android Termux 环境中运行：
 - \*\*康 (第一个 KFC 赞助者🍗)
 - \*东 (第一个咖啡赞助者☕️)
 - 炼\*3 (第一个termux 用户赞助者📱)
-- 16°C 咖啡 (我的好基友 🤪, 提供了 Claude Code max $200 套餐)
+- [chamo101](https://github.com/chamo101) (第一个 GitHub issue 赞助者 🎉)
+- 16°C 咖啡 (我的好基友 🤪, 提供了 ChatGPT Pro $200 套餐)
 
 ## 📄 许可证
 


### PR DESCRIPTION
## Description

This PR includes changes from branch `feat/docs` with 1 commit(s) since divergence from `main`.

### Key Changes:

- Documentation updates and improvements

### Files Modified:

- `README.md`
- `README_ja-JP.md`
- `README_zh-CN.md`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Code changes tested
- [x] No new warnings introduced
- [x] Code follows style guidelines
- [ ] Tests added/updated

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Code follows project guidelines

## Additional Information

**Branch:** `feat/docs` → `main`
**Commits:** 1
**Files Changed:** 3

### Commit History:

```
b950434 feat(docs): update sponsor information in README files
```

### Change Details:

This PR updates the sponsor information across all README files (English, Japanese, and Chinese):

1. **Added new sponsor**: [chamo101](https://github.com/chamo101) - first GitHub issue sponsor 🎉
2. **Updated existing sponsor**: Corrected 16°C coffee sponsor description from "Claude Code max $200 package" to "ChatGPT Pro $200 package"

These changes ensure accurate and up-to-date sponsor recognition across all language versions of the documentation.

---
🤖 Generated with /zcf-pr command