### PR TITLE
feat(config): add model configuration support for profile editing

### DIFF
--- a/src/commands/config-switch.ts
+++ b/src/commands/config-switch.ts
@@ -288,8 +288,8 @@ async function handleClaudeCodeInteractiveSwitch(): Promise<void> {
     const isCcrMode = currentProfileId === 'ccr-proxy'
     choices.push({
       name: isCcrMode
-        ? `${ansis.green('● ')}CCR Proxy ${ansis.yellow('(current)')}`
-        : `  CCR Proxy`,
+        ? `${ansis.green('● ')}${i18n.t('multi-config:ccrProxyOption')} ${ansis.yellow(`(${i18n.t('common:current')})`)}`
+        : `  ${i18n.t('multi-config:ccrProxyOption')}`,
       value: 'ccr',
     })
 

--- a/src/i18n/locales/en/multi-config.json
+++ b/src/i18n/locales/en/multi-config.json
@@ -35,6 +35,7 @@
   "authType.api_key": "API Key",
   "authType.auth_token": "Auth Token",
   "authType.ccr_proxy": "CCR Proxy",
+  "ccrProxyOption": "Use CCR Proxy",
   "profileAdded": "✔ Successfully added profile: {{name}}",
   "profileAddFailed": "❌ Failed to add profile: {{error}}",
   "profileDuplicatePrompt": "Profile '{{name}}' already exists in {{source}}, overwrite it?",

--- a/src/i18n/locales/zh-CN/multi-config.json
+++ b/src/i18n/locales/zh-CN/multi-config.json
@@ -35,6 +35,7 @@
   "authType.api_key": "API Key",
   "authType.auth_token": "Auth Token",
   "authType.ccr_proxy": "CCR 代理",
+  "ccrProxyOption": "使用 CCR 代理",
   "profileAdded": "✔ 已成功添加配置：{{name}}",
   "profileAddFailed": "❌ 添加配置失败：{{error}}",
   "profileDuplicatePrompt": "配置「{{name}}」已经存在于{{source}}，是否覆盖？",

--- a/src/utils/claude-code-incremental-manager.ts
+++ b/src/utils/claude-code-incremental-manager.ts
@@ -412,6 +412,16 @@ async function handleEditProfile(profiles: ClaudeCodeProfile[]): Promise<void> {
     },
   ])
 
+  // Prompt for model configuration (for non-CCR profiles)
+  let modelConfig: { primaryModel: string, fastModel: string } | null = null
+  if (selectedProfile.authType !== 'ccr_proxy') {
+    const { promptCustomModels } = await import('./features')
+    modelConfig = await promptCustomModels(
+      selectedProfile.primaryModel,
+      selectedProfile.fastModel,
+    )
+  }
+
   // Update profile data
   const updateData: Partial<ClaudeCodeProfile> = {
     name: answers.profileName.trim(),
@@ -420,6 +430,16 @@ async function handleEditProfile(profiles: ClaudeCodeProfile[]): Promise<void> {
   if (selectedProfile.authType !== 'ccr_proxy') {
     updateData.apiKey = answers.apiKey.trim()
     updateData.baseUrl = answers.baseUrl.trim()
+
+    // Add model configuration if provided
+    if (modelConfig) {
+      if (modelConfig.primaryModel.trim()) {
+        updateData.primaryModel = modelConfig.primaryModel.trim()
+      }
+      if (modelConfig.fastModel.trim()) {
+        updateData.fastModel = modelConfig.fastModel.trim()
+      }
+    }
   }
 
   const result = await ClaudeCodeConfigManager.updateProfile(selectedProfile.id!, updateData)

--- a/src/utils/code-tools/codex-config-switch.ts
+++ b/src/utils/code-tools/codex-config-switch.ts
@@ -275,11 +275,23 @@ async function handleEditProvider(providers: any[]): Promise<void> {
     },
   ])
 
+  // Prompt for model configuration
+  const { model } = await inquirer.prompt<{ model: string }>([
+    {
+      type: 'input',
+      name: 'model',
+      message: i18n.t('codex:providerModelPrompt'),
+      default: provider.model || 'gpt-5-codex',
+      validate: (input: string) => !!input.trim() || i18n.t('codex:providerModelRequired'),
+    },
+  ])
+
   const updates = {
     name: answers.providerName.trim(),
     baseUrl: answers.baseUrl.trim(),
     wireApi: answers.wireApi as 'responses' | 'chat',
     apiKey: answers.apiKey.trim(),
+    model: model.trim(),
   }
 
   const result = await editExistingProvider(selectedProviderId, updates)

--- a/src/utils/code-tools/codex-provider-manager.ts
+++ b/src/utils/code-tools/codex-provider-manager.ts
@@ -28,6 +28,7 @@ export interface ProviderUpdateData {
   baseUrl?: string
   wireApi?: 'responses' | 'chat'
   apiKey?: string
+  model?: string
 }
 
 /**
@@ -155,6 +156,7 @@ export async function editExistingProvider(
       ...(updates.name && { name: updates.name }),
       ...(updates.baseUrl && { baseUrl: updates.baseUrl }),
       ...(updates.wireApi && { wireApi: updates.wireApi }),
+      ...(updates.model && { model: updates.model }),
     }
 
     // Update configuration

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -394,19 +394,19 @@ export async function configureDefaultModelFeature(): Promise<void> {
  * Prompt user for custom model names
  * @returns Object containing primaryModel and fastModel strings (may be empty for skip)
  */
-export async function promptCustomModels(): Promise<{ primaryModel: string, fastModel: string }> {
+export async function promptCustomModels(defaultPrimaryModel?: string, defaultFastModel?: string): Promise<{ primaryModel: string, fastModel: string }> {
   const { primaryModel } = await inquirer.prompt<{ primaryModel: string }>({
     type: 'input',
     name: 'primaryModel',
     message: `${i18n.t('configuration:enterPrimaryModel')}${i18n.t('common:emptyToSkip')}`,
-    default: '',
+    default: defaultPrimaryModel || '',
   })
 
   const { fastModel } = await inquirer.prompt<{ fastModel: string }>({
     type: 'input',
     name: 'fastModel',
     message: `${i18n.t('configuration:enterFastModel')}${i18n.t('common:emptyToSkip')}`,
-    default: '',
+    default: defaultFastModel || '',
   })
 
   return { primaryModel, fastModel }

--- a/tests/unit/commands/config-switch.test.ts
+++ b/tests/unit/commands/config-switch.test.ts
@@ -256,6 +256,16 @@ describe('config-switch command', () => {
       expect(mockSwitchToOfficialLogin).not.toHaveBeenCalled()
       // Should not throw error, should handle gracefully
     })
+
+    it('should handle official login selection with failure', async () => {
+      mockInquirer.prompt.mockResolvedValue({ selectedConfig: 'official' })
+      mockSwitchToOfficialLogin.mockResolvedValue(false)
+
+      await configSwitchCommand({})
+
+      expect(mockSwitchToOfficialLogin).toHaveBeenCalled()
+      expect(mockSwitchToProvider).not.toHaveBeenCalled()
+    })
   })
 
   describe('error handling', () => {
@@ -271,6 +281,13 @@ describe('config-switch command', () => {
       mockSwitchCodexProvider.mockRejectedValue(error)
 
       await expect(configSwitchCommand({ target: 'claude-api' })).rejects.toThrow('Failed to write config')
+    })
+
+    it('should handle errors in interactive mode', async () => {
+      const error = new Error('Unexpected error')
+      mockListCodexProviders.mockRejectedValue(error)
+
+      await expect(configSwitchCommand({})).rejects.toThrow('Unexpected error')
     })
   })
 })

--- a/tests/unit/utils/code-tools/codex-config-switch.test.ts
+++ b/tests/unit/utils/code-tools/codex-config-switch.test.ts
@@ -171,6 +171,7 @@ describe('codex-config-switch', () => {
           wireApi: 'responses',
           apiKey: 'updated-key',
         })
+        .mockResolvedValueOnce({ model: 'gpt-5-codex' }) // Model configuration
       vi.mocked(editExistingProvider).mockResolvedValue({
         success: true,
         updatedProvider: createMockProvider('provider1', 'Updated Provider'),
@@ -181,6 +182,7 @@ describe('codex-config-switch', () => {
         baseUrl: 'https://api.updated.com',
         wireApi: 'responses',
         apiKey: 'updated-key',
+        model: 'gpt-5-codex',
       })
     })
     it('should handle delete provider action', async () => {
@@ -493,6 +495,7 @@ describe('codex-config-switch', () => {
           wireApi: 'responses',
           apiKey: 'updated-key',
         })
+        .mockResolvedValueOnce({ model: 'gpt-5-codex' }) // Model configuration
       vi.mocked(editExistingProvider).mockResolvedValue({
         success: false,
         error: 'Edit failed',
@@ -523,6 +526,7 @@ describe('codex-config-switch', () => {
           wireApi: 'responses',
           apiKey: 'updated-key',
         })
+        .mockResolvedValueOnce({ model: 'gpt-5-codex' }) // Model configuration
       vi.mocked(editExistingProvider).mockResolvedValue({
         success: true,
         updatedProvider: createMockProvider('provider1', 'Updated Provider'),


### PR DESCRIPTION
## Description

This PR adds comprehensive model configuration support when editing Claude Code profiles and Codex providers, enhancing the flexibility of multi-config management.

### Key Changes:

- New feature: Model configuration prompts for profile/provider editing
- Internationalization improvements for CCR Proxy option display
- Enhanced type definitions and test coverage

### Files Modified:

- `src/commands/config-switch.ts` - Internationalize CCR Proxy option display
- `src/i18n/locales/en/multi-config.json` - Add English translation for CCR Proxy option
- `src/i18n/locales/zh-CN/multi-config.json` - Add Chinese translation for CCR Proxy option
- `src/utils/claude-code-incremental-manager.ts` - Add model configuration prompts for profile editing
- `src/utils/code-tools/codex-config-switch.ts` - Add model configuration prompts for provider editing
- `src/utils/code-tools/codex-provider-manager.ts` - Add model field to ProviderUpdateData interface
- `src/utils/features.ts` - Update promptCustomModels to accept default values
- `tests/unit/utils/code-tools/codex-config-switch.test.ts` - Add test coverage for model configuration

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Code changes tested
- [x] No new warnings introduced
- [x] Code follows style guidelines
- [x] Tests added/updated

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Code follows project guidelines

## Additional Information

**Branch:** \`fix/api-config\` → \`main\`
**Commits:** 1
**Files Changed:** 8

### Commit History:

\`\`\`
9ce8953 feat(config): add model configuration support for profile editing
\`\`\`

### Implementation Details:

1. **Claude Code Profile Editing**: When editing a non-CCR profile, users are now prompted to configure custom models (primaryModel and fastModel) with their current values as defaults.

2. **Codex Provider Editing**: When editing a Codex provider, users can now configure the model field with the current value as default.

3. **Internationalization**: The CCR Proxy option in the config switch menu now uses i18n translations instead of hardcoded English text.

4. **Type Safety**: Added \`model\` field to \`ProviderUpdateData\` interface to ensure type safety when updating provider configurations.

5. **Test Coverage**: Updated test cases to cover the new model configuration flow, ensuring the prompts are called and values are properly passed to update functions.

### Benefits:

- **Enhanced Flexibility**: Users can now customize models when editing existing configurations without recreating them
- **Better UX**: Default values are pre-filled, making it easier to make minor adjustments
- **Consistency**: Model configuration is now available in both creation and editing workflows
- **Internationalization**: Improved i18n coverage for better multilingual support

---
🤖 Generated with /zcf-pr command