### PR TITLE
feat: add inquirer-toggle package and refactor prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "i18next": "catalog:runtime",
     "i18next-fs-backend": "catalog:runtime",
     "inquirer": "catalog:cli",
+    "inquirer-toggle": "catalog:cli",
     "ora": "catalog:cli",
     "pathe": "catalog:runtime",
     "semver": "catalog:runtime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ catalogs:
     inquirer:
       specifier: ^12.9.6
       version: 12.9.6
+    inquirer-toggle:
+      specifier: ^1.0.1
+      version: 1.0.1
     ora:
       specifier: ^9.0.0
       version: 9.0.0
@@ -145,6 +148,9 @@ importers:
       inquirer:
         specifier: catalog:cli
         version: 12.9.6(@types/node@22.18.6)
+      inquirer-toggle:
+        specifier: catalog:cli
+        version: 1.0.1
       ora:
         specifier: catalog:cli
         version: 9.0.0
@@ -726,6 +732,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/core@8.2.4':
+    resolution: {integrity: sha512-7vsXSfxtrrbwMTirfaKwPcjqJy7pzeuF/bP62yo1NQrRJ5HjmMlrhZml/Ljm9ODc1RnbhJlTeSnCkjtFddKjwA==}
+    engines: {node: '>=18'}
+
   '@inquirer/editor@4.2.20':
     resolution: {integrity: sha512-7omh5y5bK672Q+Brk4HBbnHNowOZwrb/78IFXdrEB9PfdxL3GudQyDk8O9vQ188wj3xrEebS2M9n18BjJoI83g==}
     engines: {node: '>=18'}
@@ -828,6 +838,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@inquirer/type@1.5.5':
+    resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
+    engines: {node: '>=18'}
 
   '@inquirer/type@3.0.8':
     resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
@@ -1114,8 +1128,14 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mute-stream@0.0.4':
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@20.19.25':
+    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
   '@types/node@22.18.6':
     resolution: {integrity: sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==}
@@ -1131,6 +1151,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@typescript-eslint/eslint-plugin@8.44.1':
     resolution: {integrity: sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==}
@@ -1322,6 +1345,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
     engines: {node: '>=18'}
@@ -1470,6 +1497,10 @@ packages:
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   cli-spinners@3.2.1:
     resolution: {integrity: sha512-Xh+cRh7dzk9n7gYE+M1Lusy3yg5ADy9m6zOHqmcu9kSkWpo7ySWVUS3dXleR3konJOEOdHzsKjWkGed6g2eJuA==}
@@ -2234,6 +2265,9 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  inquirer-toggle@1.0.1:
+    resolution: {integrity: sha512-0cReq29SpyO4JnoVmGBZJPoBv8sBzsGXw3MDjNxilOzhAFxIvC8mOFj34bCMtlFYKfkBKNYVLmmnP/qmrVuVMg==}
+
   inquirer@12.9.6:
     resolution: {integrity: sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==}
     engines: {node: '>=18'}
@@ -2732,6 +2766,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -3497,6 +3535,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@4.2.0:
     resolution: {integrity: sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==}
@@ -4295,6 +4337,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.6
 
+  '@inquirer/core@8.2.4':
+    dependencies:
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 1.5.5
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.19.25
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      picocolors: 1.1.1
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   '@inquirer/editor@4.2.20(@types/node@22.18.6)':
     dependencies:
       '@inquirer/core': 10.2.2(@types/node@22.18.6)
@@ -4390,6 +4448,10 @@ snapshots:
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.18.6
+
+  '@inquirer/type@1.5.5':
+    dependencies:
+      mute-stream: 1.0.0
 
   '@inquirer/type@3.0.8(@types/node@22.18.6)':
     optionalDependencies:
@@ -4630,7 +4692,15 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mute-stream@0.0.4':
+    dependencies:
+      '@types/node': 22.18.6
+
   '@types/node@12.20.55': {}
+
+  '@types/node@20.19.25':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.18.6':
     dependencies:
@@ -4645,6 +4715,8 @@ snapshots:
       '@types/node': 22.18.6
 
   '@types/unist@3.0.3': {}
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -4933,6 +5005,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@7.0.0:
     dependencies:
       environment: 1.1.0
@@ -5064,6 +5140,8 @@ snapshots:
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   cli-spinners@3.2.1: {}
 
@@ -5909,6 +5987,10 @@ snapshots:
 
   ini@4.1.1: {}
 
+  inquirer-toggle@1.0.1:
+    dependencies:
+      '@inquirer/core': 8.2.4
+
   inquirer@12.9.6(@types/node@22.18.6):
     dependencies:
       '@inquirer/ansi': 1.0.0
@@ -6557,6 +6639,8 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  mute-stream@1.0.0: {}
 
   mute-stream@2.0.0: {}
 
@@ -7257,6 +7341,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.21.3: {}
 
   type-fest@4.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ catalogs:
     ansis: ^4.1.0
     cac: ^6.7.14
     inquirer: ^12.9.6
+    inquirer-toggle: ^1.0.1
     ora: ^9.0.0
   runtime:
     dayjs: ^1.11.18

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -46,6 +46,7 @@ import { configureOutputStyle } from '../utils/output-style'
 import { isTermux, isWindows } from '../utils/platform'
 import { addNumbersToChoices } from '../utils/prompt-helpers'
 import { resolveAiOutputLanguage } from '../utils/prompts'
+import { promptBoolean } from '../utils/toggle-prompt'
 import { formatApiKeyDisplay } from '../utils/validator'
 import { checkClaudeCodeVersionAndPrompt } from '../utils/version-checker'
 import { selectAndInstallWorkflows } from '../utils/workflow-installer'
@@ -511,17 +512,10 @@ export async function init(options: InitOptions = {}): Promise<void> {
         await installClaudeCode()
       }
       else {
-        const { shouldInstall } = await inquirer.prompt<{ shouldInstall: boolean }>({
-          type: 'confirm',
-          name: 'shouldInstall',
+        const shouldInstall = await promptBoolean({
           message: i18n.t('installation:installPrompt'),
-          default: true,
+          defaultValue: true,
         })
-
-        if (shouldInstall === undefined) {
-          console.log(ansis.yellow(i18n.t('common:cancelled')))
-          process.exit(0)
-        }
 
         if (shouldInstall) {
           await installClaudeCode()
@@ -816,17 +810,10 @@ export async function init(options: InitOptions = {}): Promise<void> {
         shouldConfigureMcp = options.mcpServices !== false
       }
       else {
-        const { shouldConfigureMcp: userChoice } = await inquirer.prompt<{ shouldConfigureMcp: boolean }>({
-          type: 'confirm',
-          name: 'shouldConfigureMcp',
+        const userChoice = await promptBoolean({
           message: i18n.t('mcp:configureMcp'),
-          default: true,
+          defaultValue: true,
         })
-
-        if (userChoice === undefined) {
-          console.log(ansis.yellow(i18n.t('common:cancelled')))
-          process.exit(0)
-        }
 
         shouldConfigureMcp = userChoice
       }
@@ -937,17 +924,10 @@ export async function init(options: InitOptions = {}): Promise<void> {
         shouldInstallCometix = options.installCometixLine !== false
       }
       else {
-        const { shouldInstallCometix: userChoice } = await inquirer.prompt<{ shouldInstallCometix: boolean }>({
-          type: 'confirm',
-          name: 'shouldInstallCometix',
+        const userChoice = await promptBoolean({
           message: i18n.t('cometix:installCometixPrompt'),
-          default: true,
+          defaultValue: true,
         })
-
-        if (userChoice === undefined) {
-          console.log(ansis.yellow(i18n.t('common:cancelled')))
-          process.exit(0)
-        }
 
         shouldInstallCometix = userChoice
       }

--- a/src/commands/menu.ts
+++ b/src/commands/menu.ts
@@ -18,6 +18,7 @@ import {
   configureMcpFeature,
 } from '../utils/features'
 import { addNumbersToChoices } from '../utils/prompt-helpers'
+import { promptBoolean } from '../utils/toggle-prompt'
 import { runCcrMenuFeature, runCcusageFeature, runCometixMenuFeature } from '../utils/tools'
 import { readZcfConfig, updateZcfConfig } from '../utils/zcf-config'
 import { checkUpdates } from './check-updates'
@@ -234,11 +235,9 @@ async function showClaudeCodeMenu(): Promise<MenuResult> {
 
   printSeparator()
 
-  const { continue: shouldContinue } = await inquirer.prompt<{ continue: boolean }>({
-    type: 'confirm',
-    name: 'continue',
+  const shouldContinue = await promptBoolean({
     message: i18n.t('common:returnToMenu'),
-    default: true,
+    defaultValue: true,
   })
 
   if (!shouldContinue) {
@@ -345,11 +344,9 @@ async function showCodexMenu(): Promise<MenuResult> {
 
   printSeparator()
 
-  const { continue: shouldContinue } = await inquirer.prompt<{ continue: boolean }>({
-    type: 'confirm',
-    name: 'continue',
+  const shouldContinue = await promptBoolean({
     message: i18n.t('common:returnToMenu'),
-    default: true,
+    defaultValue: true,
   })
 
   if (!shouldContinue) {

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -5,6 +5,7 @@ import inquirer from 'inquirer'
 import { ensureI18nInitialized, i18n } from '../i18n'
 import { handleExitPromptError, handleGeneralError } from '../utils/error-handler'
 import { addNumbersToChoices } from '../utils/prompt-helpers'
+import { promptBoolean } from '../utils/toggle-prompt'
 import { ZcfUninstaller } from '../utils/uninstaller'
 
 export interface UninstallOptions {
@@ -177,11 +178,9 @@ async function executeCompleteUninstall(uninstaller: ZcfUninstaller): Promise<vo
   console.log(ansis.yellow(i18n.t('uninstall:completeWarning')))
 
   // Final confirmation
-  const { confirm } = await inquirer.prompt<{ confirm: boolean }>({
-    type: 'confirm',
-    name: 'confirm',
+  const confirm = await promptBoolean({
     message: i18n.t('uninstall:confirmComplete'),
-    default: false,
+    defaultValue: false,
   })
 
   if (!confirm) {
@@ -210,11 +209,9 @@ async function executeCustomUninstall(uninstaller: ZcfUninstaller, items: Uninst
   })
 
   // Final confirmation
-  const { confirm } = await inquirer.prompt<{ confirm: boolean }>({
-    type: 'confirm',
-    name: 'confirm',
+  const confirm = await promptBoolean({
     message: i18n.t('uninstall:confirmCustom'),
-    default: false,
+    defaultValue: false,
   })
 
   if (!confirm) {

--- a/src/utils/auto-updater.ts
+++ b/src/utils/auto-updater.ts
@@ -1,9 +1,9 @@
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import ansis from 'ansis'
-import inquirer from 'inquirer'
 import ora from 'ora'
 import { ensureI18nInitialized, format, i18n } from '../i18n'
+import { promptBoolean } from './toggle-prompt'
 import { checkCcrVersion, checkClaudeCodeVersion, checkCometixLineVersion } from './version-checker'
 
 const execAsync = promisify(exec)
@@ -38,11 +38,9 @@ export async function updateCcr(force = false, skipPrompt = false): Promise<bool
     // Handle confirmation based on skipPrompt mode
     if (!skipPrompt) {
       // Interactive mode: Ask for confirmation
-      const { confirm } = await inquirer.prompt<{ confirm: boolean }>({
-        type: 'confirm',
-        name: 'confirm',
+      const confirm = await promptBoolean({
         message: format(i18n.t('updater:confirmUpdate'), { tool: 'CCR' }),
-        default: true,
+        defaultValue: true,
       })
 
       if (!confirm) {
@@ -107,11 +105,9 @@ export async function updateClaudeCode(force = false, skipPrompt = false): Promi
     // Handle confirmation based on skipPrompt mode
     if (!skipPrompt) {
       // Interactive mode: Ask for confirmation
-      const { confirm } = await inquirer.prompt<{ confirm: boolean }>({
-        type: 'confirm',
-        name: 'confirm',
+      const confirm = await promptBoolean({
         message: format(i18n.t('updater:confirmUpdate'), { tool: 'Claude Code' }),
-        default: true,
+        defaultValue: true,
       })
 
       if (!confirm) {
@@ -175,11 +171,9 @@ export async function updateCometixLine(force = false, skipPrompt = false): Prom
     // Handle confirmation based on skipPrompt mode
     if (!skipPrompt) {
       // Interactive mode: Ask for confirmation
-      const { confirm } = await inquirer.prompt<{ confirm: boolean }>({
-        type: 'confirm',
-        name: 'confirm',
+      const confirm = await promptBoolean({
         message: format(i18n.t('updater:confirmUpdate'), { tool: 'CCometixLine' }),
-        default: true,
+        defaultValue: true,
       })
 
       if (!confirm) {

--- a/src/utils/ccr/config.ts
+++ b/src/utils/ccr/config.ts
@@ -13,6 +13,7 @@ import { ensureI18nInitialized, i18n } from '../../i18n'
 import { addCompletedOnboarding, setPrimaryApiKey } from '../claude-config'
 import { backupExistingConfig } from '../config'
 import { readJsonConfig, writeJsonConfig } from '../json-config'
+import { promptBoolean } from '../toggle-prompt'
 import { fetchProviderPresets } from './presets'
 
 const execAsync = promisify(exec)
@@ -297,13 +298,10 @@ export async function setupCcrConfiguration(): Promise<boolean> {
       console.log(ansis.blue(`ℹ ${i18n.t('ccr:existingCcrConfig')}`))
       let shouldBackupAndReconfigure = false
       try {
-        const result = await inquirer.prompt<{ overwrite: boolean }>({
-          type: 'confirm',
-          name: 'overwrite',
+        shouldBackupAndReconfigure = await promptBoolean({
           message: i18n.t('ccr:overwriteCcrConfig'),
-          default: false,
+          defaultValue: false,
         })
-        shouldBackupAndReconfigure = result.overwrite
       }
       catch (error: any) {
         if (error.name === 'ExitPromptError') {

--- a/src/utils/claude-code-incremental-manager.ts
+++ b/src/utils/claude-code-incremental-manager.ts
@@ -4,6 +4,7 @@ import inquirer from 'inquirer'
 import { ensureI18nInitialized, i18n } from '../i18n'
 import { ClaudeCodeConfigManager } from './claude-code-config-manager'
 import { addNumbersToChoices } from './prompt-helpers'
+import { promptBoolean } from './toggle-prompt'
 import { validateApiKey } from './validator'
 // Inline i18n helper to avoid extra file
 function getAuthTypeLabel(authType: ClaudeCodeProfile['authType']): string {
@@ -81,14 +82,10 @@ export async function configureIncrementalManagement(): Promise<void> {
 }
 
 async function promptContinueAdding(): Promise<boolean> {
-  const { continueAdding } = await inquirer.prompt<{ continueAdding: boolean }>([{
-    type: 'confirm',
-    name: 'continueAdding',
+  return await promptBoolean({
     message: i18n.t('multi-config:addAnotherProfilePrompt'),
-    default: false,
-  }])
-
-  return continueAdding
+    defaultValue: false,
+  })
 }
 
 /**
@@ -215,14 +212,10 @@ async function handleAddProfile(): Promise<void> {
   }
 
   // Continue with setAsDefault prompt
-  const { setAsDefault } = await inquirer.prompt<{ setAsDefault: boolean }>([
-    {
-      type: 'confirm',
-      name: 'setAsDefault',
-      message: i18n.t('multi-config:setAsDefaultPrompt'),
-      default: true,
-    },
-  ])
+  const setAsDefault = await promptBoolean({
+    message: i18n.t('multi-config:setAsDefaultPrompt'),
+    defaultValue: true,
+  })
 
   // Create profile object
   const profileName = answers.profileName.trim()
@@ -258,15 +251,13 @@ async function handleAddProfile(): Promise<void> {
 
   const existingProfile = ClaudeCodeConfigManager.getProfileByName(profile.name)
   if (existingProfile) {
-    const { overwrite } = await inquirer.prompt<{ overwrite: boolean }>([{
-      type: 'confirm',
-      name: 'overwrite',
+    const overwrite = await promptBoolean({
       message: i18n.t('multi-config:profileDuplicatePrompt', {
         name: profile.name,
         source: i18n.t('multi-config:existingConfig'),
       }),
-      default: false,
-    }])
+      defaultValue: false,
+    })
 
     if (!overwrite) {
       console.log(ansis.yellow(i18n.t('multi-config:profileDuplicateSkipped', { name: profile.name })))
@@ -593,14 +584,10 @@ async function handleCopyProfile(profiles: ClaudeCodeProfile[]): Promise<void> {
   }
 
   // Ask if set as default
-  const { setAsDefault } = await inquirer.prompt<{ setAsDefault: boolean }>([
-    {
-      type: 'confirm',
-      name: 'setAsDefault',
-      message: i18n.t('multi-config:setAsDefaultPrompt'),
-      default: false,
-    },
-  ])
+  const setAsDefault = await promptBoolean({
+    message: i18n.t('multi-config:setAsDefaultPrompt'),
+    defaultValue: false,
+  })
 
   // Create copied profile object
   const profileName = answers.profileName.trim()
@@ -688,12 +675,10 @@ async function handleDeleteProfile(profiles: ClaudeCodeProfile[]): Promise<void>
     profiles.find(p => p.id === id)?.name || id,
   )
 
-  const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([{
-    type: 'confirm',
-    name: 'confirmed',
+  const confirmed = await promptBoolean({
     message: i18n.t('multi-config:confirmDeleteProfiles', { providers: selectedNames.join(', ') }),
-    default: false,
-  }])
+    defaultValue: false,
+  })
 
   if (!confirmed) {
     console.log(ansis.yellow(i18n.t('common:cancelled')))

--- a/src/utils/code-tools/codex-config-switch.ts
+++ b/src/utils/code-tools/codex-config-switch.ts
@@ -5,6 +5,7 @@ import { CODEX_AUTH_FILE } from '../../constants'
 import { ensureI18nInitialized, i18n } from '../../i18n'
 import { readJsonConfig } from '../json-config'
 import { addNumbersToChoices } from '../prompt-helpers'
+import { promptBoolean } from '../toggle-prompt'
 import { detectConfigManagementMode } from './codex-config-detector'
 import { addProviderToExisting, deleteProviders, editExistingProvider } from './codex-provider-manager'
 
@@ -154,15 +155,13 @@ async function handleAddProvider(): Promise<void> {
   const existingProvider = managementMode.providers?.find((p: any) => p.id === providerId)
 
   if (existingProvider) {
-    const { shouldOverwrite } = await inquirer.prompt<{ shouldOverwrite: boolean }>([{
-      type: 'confirm',
-      name: 'shouldOverwrite',
+    const shouldOverwrite = await promptBoolean({
       message: i18n.t('codex:providerDuplicatePrompt', {
         name: existingProvider.name,
         source: i18n.t('codex:existingConfig'),
       }),
-      default: false,
-    }])
+      defaultValue: false,
+    })
 
     if (!shouldOverwrite) {
       console.log(ansis.yellow(i18n.t('codex:providerDuplicateSkipped')))
@@ -189,12 +188,10 @@ async function handleAddProvider(): Promise<void> {
     }
 
     // Ask if user wants to set this provider as default
-    const { setAsDefault } = await inquirer.prompt<{ setAsDefault: boolean }>([{
-      type: 'confirm',
-      name: 'setAsDefault',
+    const setAsDefault = await promptBoolean({
       message: i18n.t('multi-config:setAsDefaultPrompt'),
-      default: true,
-    }])
+      defaultValue: true,
+    })
 
     if (setAsDefault) {
       const { switchToProvider } = await import('./codex')
@@ -432,12 +429,10 @@ async function handleCopyProvider(providers: any[]): Promise<void> {
     }
 
     // Ask if user wants to set this provider as default
-    const { setAsDefault } = await inquirer.prompt<{ setAsDefault: boolean }>([{
-      type: 'confirm',
-      name: 'setAsDefault',
+    const setAsDefault = await promptBoolean({
       message: i18n.t('multi-config:setAsDefaultPrompt'),
-      default: false,
-    }])
+      defaultValue: false,
+    })
 
     if (setAsDefault) {
       const { switchToProvider } = await import('./codex')
@@ -488,12 +483,10 @@ async function handleDeleteProvider(providers: any[]): Promise<void> {
     providers.find(p => p.id === id)?.name || id,
   ).join(', ')
 
-  const { confirmDelete } = await inquirer.prompt<{ confirmDelete: boolean }>([{
-    type: 'confirm',
-    name: 'confirmDelete',
+  const confirmDelete = await promptBoolean({
     message: i18n.t('codex:confirmDeleteProviders', { providers: selectedNames }),
-    default: false,
-  }])
+    defaultValue: false,
+  })
 
   if (!confirmDelete) {
     console.log(ansis.yellow(i18n.t('common:cancelled')))

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -20,6 +20,7 @@ import { wrapCommandWithSudo } from '../platform'
 // Removed MCP selection and platform command imports from this module
 import { addNumbersToChoices } from '../prompt-helpers'
 import { resolveAiOutputLanguage } from '../prompts'
+import { promptBoolean } from '../toggle-prompt'
 import { readZcfConfig, updateZcfConfig } from '../zcf-config'
 import { detectConfigManagementMode } from './codex-config-detector'
 import { configureCodexMcp } from './codex-configure'
@@ -1304,15 +1305,13 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
       const sourceType = existingProvider ? 'existing' : 'session'
       const sourceProvider = existingProvider || sessionProvider
 
-      const { shouldOverwrite } = await inquirer.prompt<{ shouldOverwrite: boolean }>([{
-        type: 'confirm',
-        name: 'shouldOverwrite',
+      const shouldOverwrite = await promptBoolean({
         message: i18n.t('codex:providerDuplicatePrompt', {
           name: sourceProvider!.name,
           source: sourceType === 'existing' ? i18n.t('codex:existingConfig') : i18n.t('codex:currentSession'),
         }),
-        default: false,
-      }])
+        defaultValue: false,
+      })
 
       if (!shouldOverwrite) {
         console.log(ansis.yellow(i18n.t('codex:providerDuplicateSkipped')))
@@ -1343,12 +1342,10 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
     currentSessionProviders.set(providerId, newProvider)
     authEntries[envKey] = answers.apiKey
 
-    const { addAnother } = await inquirer.prompt<{ addAnother: boolean }>([{
-      type: 'confirm',
-      name: 'addAnother',
+    const addAnother = await promptBoolean({
       message: i18n.t('codex:addProviderPrompt'),
-      default: false,
-    }])
+      defaultValue: false,
+    })
 
     addMore = addAnother
   }
@@ -1492,11 +1489,9 @@ export async function runCodexUpdate(force = false, skipPrompt = false): Promise
     // Handle confirmation based on skipPrompt mode
     if (!skipPrompt) {
       // Interactive mode: Ask for confirmation
-      const { confirm } = await inquirer.prompt<{ confirm: boolean }>({
-        type: 'confirm',
-        name: 'confirm',
+      const confirm = await promptBoolean({
         message: i18n.t('codex:confirmUpdate'),
-        default: true,
+        defaultValue: true,
       })
 
       if (!confirm) {
@@ -1563,12 +1558,10 @@ export async function runCodexUninstall(): Promise<void> {
   try {
     if (mode === 'complete') {
       // Step 2a: Complete uninstall
-      const { confirm } = await inquirer.prompt<{ confirm: boolean }>([{
-        type: 'confirm',
-        name: 'confirm',
+      const confirm = await promptBoolean({
         message: i18n.t('codex:uninstallPrompt'),
-        default: false,
-      }])
+        defaultValue: false,
+      })
 
       if (!confirm) {
         handleUninstallCancellation()

--- a/src/utils/cometix/menu.ts
+++ b/src/utils/cometix/menu.ts
@@ -2,6 +2,7 @@ import ansis from 'ansis'
 import inquirer from 'inquirer'
 import { ensureI18nInitialized, i18n } from '../../i18n'
 import { handleExitPromptError, handleGeneralError } from '../error-handler'
+import { promptBoolean } from '../toggle-prompt'
 import { runCometixPrintConfig, runCometixTuiConfig } from './commands'
 import { installCometixLine } from './installer'
 
@@ -54,11 +55,9 @@ export async function showCometixMenu(): Promise<boolean> {
     // Ask if user wants to continue in CCometixLine menu
     if (choice !== '0') {
       console.log(`\n${ansis.dim('─'.repeat(50))}\n`)
-      const { continueInCometix } = await inquirer.prompt<{ continueInCometix: boolean }>({
-        type: 'confirm',
-        name: 'continueInCometix',
+      const continueInCometix = await promptBoolean({
         message: i18n.t('common:returnToMenu'),
-        default: true,
+        defaultValue: true,
       })
 
       if (continueInCometix) {

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -31,6 +31,7 @@ import { configureOutputStyle } from './output-style'
 import { isWindows } from './platform'
 import { addNumbersToChoices } from './prompt-helpers'
 import { importRecommendedEnv, importRecommendedPermissions, openSettingsJson } from './simple-config'
+import { promptBoolean } from './toggle-prompt'
 import { formatApiKeyDisplay, validateApiKey } from './validator'
 import { readZcfConfig, updateZcfConfig } from './zcf-config'
 
@@ -245,11 +246,9 @@ export async function configureMcpFeature(): Promise<void> {
 
   // Check if Windows needs fix
   if (isWindows()) {
-    const { fixWindows } = await inquirer.prompt<{ fixWindows: boolean }>({
-      type: 'confirm',
-      name: 'fixWindows',
+    const fixWindows = await promptBoolean({
       message: i18n.t('configuration:fixWindowsMcp') || 'Fix Windows MCP configuration?',
-      default: true,
+      defaultValue: true,
     })
 
     if (fixWindows) {
@@ -327,11 +326,9 @@ export async function configureDefaultModelFeature(): Promise<void> {
     console.log(ansis.gray(`  ${i18n.t('configuration:currentModel') || 'Current model'}: ${modelDisplay}\n`))
 
     // Ask user what to do with existing config
-    const { modify } = await inquirer.prompt<{ modify: boolean }>({
-      type: 'confirm',
-      name: 'modify',
+    const modify = await promptBoolean({
       message: i18n.t('configuration:modifyModel') || 'Modify model configuration?',
-      default: false,
+      defaultValue: false,
     })
 
     if (!modify) {
@@ -448,11 +445,9 @@ export async function configureAiMemoryFeature(): Promise<void> {
       )
       console.log(ansis.gray(`  ${i18n.t('configuration:currentLanguage') || 'Current language'}: ${existingLang}\n`))
 
-      const { modify } = await inquirer.prompt<{ modify: boolean }>({
-        type: 'confirm',
-        name: 'modify',
+      const modify = await promptBoolean({
         message: i18n.t('configuration:modifyLanguage') || 'Modify AI output language?',
-        default: false,
+        defaultValue: false,
       })
 
       if (!modify) {
@@ -525,11 +520,9 @@ export async function configureCodexDefaultModelFeature(): Promise<void> {
     console.log(ansis.gray(`  ${i18n.t('configuration:currentModel') || 'Current model'}: ${modelDisplay}\n`))
 
     // Ask user what to do with existing config
-    const { modify } = await inquirer.prompt<{ modify: boolean }>({
-      type: 'confirm',
-      name: 'modify',
+    const modify = await promptBoolean({
       message: i18n.t('configuration:modifyModel') || 'Modify model configuration?',
-      default: false,
+      defaultValue: false,
     })
 
     if (!modify) {
@@ -626,11 +619,9 @@ export async function configureCodexAiMemoryFeature(): Promise<void> {
       )
       console.log(ansis.gray(`  ${i18n.t('configuration:currentLanguage') || 'Current language'}: ${existingLang}\n`))
 
-      const { modify } = await inquirer.prompt<{ modify: boolean }>({
-        type: 'confirm',
-        name: 'modify',
+      const modify = await promptBoolean({
         message: i18n.t('configuration:modifyLanguage') || 'Modify AI output language?',
-        default: false,
+        defaultValue: false,
       })
 
       if (!modify) {

--- a/src/utils/output-style.ts
+++ b/src/utils/output-style.ts
@@ -9,6 +9,7 @@ import { ensureI18nInitialized, i18n } from '../i18n'
 import { copyFile, ensureDir, exists, removeFile } from './fs-operations'
 import { readJsonConfig, writeJsonConfig } from './json-config'
 import { addNumbersToChoices } from './prompt-helpers'
+import { promptBoolean } from './toggle-prompt'
 import { updateZcfConfig } from './zcf-config'
 
 export interface OutputStyle {
@@ -160,11 +161,9 @@ export async function configureOutputStyle(
   if (hasLegacyPersonalityFiles() && !preselectedStyles) {
     console.log(ansis.yellow(`⚠️  ${i18n.t('configuration:legacyFilesDetected')}`))
 
-    const { cleanupLegacy } = await inquirer.prompt<{ cleanupLegacy: boolean }>({
-      type: 'confirm',
-      name: 'cleanupLegacy',
+    const cleanupLegacy = await promptBoolean({
       message: i18n.t('configuration:cleanupLegacyFiles'),
-      default: true,
+      defaultValue: true,
     })
 
     if (cleanupLegacy) {

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -8,6 +8,7 @@ import { version } from '../../package.json'
 import { AI_OUTPUT_LANGUAGES, getAiOutputLanguageLabel, LANG_LABELS, SUPPORTED_LANGS } from '../constants'
 import { ensureI18nInitialized, i18n } from '../i18n'
 import { addNumbersToChoices } from './prompt-helpers'
+import { promptBoolean } from './toggle-prompt'
 import { readZcfConfig, updateZcfConfig } from './zcf-config'
 
 /**
@@ -143,17 +144,10 @@ export async function resolveAiOutputLanguage(
     const currentLanguageLabel = getAiOutputLanguageLabel(savedConfig.aiOutputLang as AiOutputLanguage) || savedConfig.aiOutputLang
     console.log(ansis.blue(`${i18n.t('language:currentConfigFound')}: ${currentLanguageLabel}`))
 
-    const { shouldModify } = await inquirer.prompt<{ shouldModify: boolean }>({
-      type: 'confirm',
-      name: 'shouldModify',
+    const shouldModify = await promptBoolean({
       message: i18n.t('language:modifyConfigPrompt'),
-      default: false,
+      defaultValue: false,
     })
-
-    if (shouldModify === undefined) {
-      console.log(ansis.yellow(i18n.t('common:cancelled')))
-      process.exit(0)
-    }
 
     if (!shouldModify) {
       console.log(ansis.gray(`✔ ${i18n.t('language:aiOutputLangHint')}: ${currentLanguageLabel}`))
@@ -233,17 +227,10 @@ export async function resolveTemplateLanguage(
     const currentLanguageLabel = LANG_LABELS[savedConfig.templateLang]
     console.log(ansis.blue(`${i18n.t('language:currentTemplateLanguageFound')}: ${currentLanguageLabel}`))
 
-    const { shouldModify } = await inquirer.prompt<{ shouldModify: boolean }>({
-      type: 'confirm',
-      name: 'shouldModify',
+    const shouldModify = await promptBoolean({
       message: i18n.t('language:modifyTemplateLanguagePrompt'),
-      default: false,
+      defaultValue: false,
     })
-
-    if (shouldModify === undefined) {
-      console.log(ansis.yellow(i18n.t('common:cancelled')))
-      process.exit(0)
-    }
 
     if (!shouldModify) {
       console.log(ansis.gray(`✔ ${i18n.t('language:selectConfigLang')}: ${currentLanguageLabel}`))
@@ -264,17 +251,10 @@ export async function resolveTemplateLanguage(
     // Interactive mode: ask for modification
     console.log(ansis.yellow(`${i18n.t('language:usingFallbackTemplate')}: ${LANG_LABELS[savedConfig.preferredLang]}`))
 
-    const { shouldModify } = await inquirer.prompt<{ shouldModify: boolean }>({
-      type: 'confirm',
-      name: 'shouldModify',
+    const shouldModify = await promptBoolean({
       message: i18n.t('language:modifyTemplateLanguagePrompt'),
-      default: false,
+      defaultValue: false,
     })
-
-    if (shouldModify === undefined) {
-      console.log(ansis.yellow(i18n.t('common:cancelled')))
-      process.exit(0)
-    }
 
     if (!shouldModify) {
       // First time migration - save the preferred language as template language
@@ -326,17 +306,10 @@ export async function resolveSystemPromptStyle(
       // Interactive mode: ask for modification
       console.log(ansis.blue(`${i18n.t('language:currentSystemPromptFound')}: ${currentStyle.name}`))
 
-      const { shouldModify } = await inquirer.prompt<{ shouldModify: boolean }>({
-        type: 'confirm',
-        name: 'shouldModify',
+      const shouldModify = await promptBoolean({
         message: i18n.t('language:modifySystemPromptPrompt'),
-        default: false,
+        defaultValue: false,
       })
-
-      if (shouldModify === undefined) {
-        console.log(ansis.yellow(i18n.t('common:cancelled')))
-        process.exit(0)
-      }
 
       if (!shouldModify) {
         console.log(ansis.gray(`✔ ${i18n.t('language:currentSystemPromptFound')}: ${currentStyle.name}`))

--- a/src/utils/toggle-prompt.ts
+++ b/src/utils/toggle-prompt.ts
@@ -1,0 +1,29 @@
+import toggleModule from 'inquirer-toggle'
+
+const togglePrompt: typeof import('inquirer-toggle')['default'] = (
+  (toggleModule as any)?.default?.default
+  || (toggleModule as any)?.default
+  || toggleModule
+) as typeof import('inquirer-toggle')['default']
+
+type ToggleOptions = Parameters<typeof togglePrompt>[0]
+
+export interface BooleanPromptOptions {
+  message: string
+  defaultValue?: boolean
+  theme?: ToggleOptions['theme']
+}
+
+/**
+ * Wrapper around inquirer-toggle to keep boolean prompts consistent.
+ * Keeps the API minimal to align with KISS/YAGNI while allowing optional theme overrides.
+ */
+export async function promptBoolean(options: BooleanPromptOptions): Promise<boolean> {
+  const { message, defaultValue = false, theme } = options
+
+  return await togglePrompt({
+    message,
+    default: defaultValue,
+    ...(theme ? { theme } : {}),
+  })
+}

--- a/src/utils/tools/ccr-menu.ts
+++ b/src/utils/tools/ccr-menu.ts
@@ -14,6 +14,7 @@ import {
 import { configureCcrFeature, readCcrConfig } from '../ccr/config'
 import { installCcr, isCcrInstalled } from '../ccr/installer'
 import { handleExitPromptError, handleGeneralError } from '../error-handler'
+import { promptBoolean } from '../toggle-prompt'
 
 // Helper function to check if CCR is properly configured
 function isCcrConfigured(): boolean {
@@ -138,11 +139,9 @@ export async function showCcrMenu(): Promise<boolean> {
     // Ask if user wants to continue in CCR menu
     if (choice !== '0') {
       console.log(`\n${ansis.dim('─'.repeat(50))}\n`)
-      const { continueInCcr } = await inquirer.prompt<{ continueInCcr: boolean }>({
-        type: 'confirm',
-        name: 'continueInCcr',
+      const continueInCcr = await promptBoolean({
         message: i18n.t('common:returnToMenu'),
-        default: true,
+        defaultValue: true,
       })
 
       if (continueInCcr) {

--- a/tests/commands/uninstall.edge.test.ts
+++ b/tests/commands/uninstall.edge.test.ts
@@ -9,6 +9,9 @@ vi.mock('../../src/i18n')
 vi.mock('../../src/utils/uninstaller')
 vi.mock('../../src/utils/error-handler')
 vi.mock('../../src/utils/prompt-helpers')
+vi.mock('../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
+}))
 
 // Enhanced mock modules for edge cases
 const mockInquirer = vi.hoisted(() => ({
@@ -77,8 +80,9 @@ vi.mocked(ansisModule).default = mockAnsis as any
 describe('uninstall command - Edge Cases', () => {
   let mockUninstallerInstance: any
   let consoleSpy: any
+  let mockedPromptBoolean: any
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockUninstallerInstance = {
       completeUninstall: vi.fn(),
       customUninstall: vi.fn(),
@@ -87,6 +91,12 @@ describe('uninstall command - Edge Cases', () => {
 
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.clearAllMocks()
+
+    // Get mocked promptBoolean
+    const togglePromptModule = await import('../../src/utils/toggle-prompt')
+    mockedPromptBoolean = vi.mocked(togglePromptModule.promptBoolean)
+    // Default promptBoolean to return false to avoid hanging
+    mockedPromptBoolean.mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -98,7 +108,7 @@ describe('uninstall command - Edge Cases', () => {
       mockUninstallerInstance.customUninstall.mockResolvedValue([
         { success: true, removed: [], errors: [], warnings: [] },
       ])
-      mockInquirer.prompt.mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       const options: UninstallOptions = {
         mode: 'custom',
@@ -118,7 +128,7 @@ describe('uninstall command - Edge Cases', () => {
       mockUninstallerInstance.customUninstall.mockResolvedValue([
         { success: true, removed: [], errors: [], warnings: [] },
       ])
-      mockInquirer.prompt.mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       const options: UninstallOptions = {
         mode: 'custom',
@@ -146,7 +156,7 @@ describe('uninstall command - Edge Cases', () => {
       mockUninstallerInstance.customUninstall.mockResolvedValue([
         { success: true, removed: [], errors: [], warnings: [] },
       ])
-      mockInquirer.prompt.mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       const options: UninstallOptions = {
         mode: 'custom',
@@ -163,7 +173,7 @@ describe('uninstall command - Edge Cases', () => {
     it('should initialize with zh-CN language', async () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: false }) // User cancels
+        // promptBoolean will return false by default // User cancels
 
       const options: UninstallOptions = {
         lang: 'zh-CN',
@@ -177,7 +187,7 @@ describe('uninstall command - Edge Cases', () => {
     it('should handle default language when not specified', async () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: false })
+        // promptBoolean will return false by default
 
       await uninstall()
 
@@ -207,7 +217,7 @@ describe('uninstall command - Edge Cases', () => {
     it('should handle complete uninstall cancellation', async () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: false })
+        // promptBoolean will return false by default
 
       await uninstall()
 
@@ -241,7 +251,7 @@ describe('uninstall command - Edge Cases', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'custom' })
         .mockResolvedValueOnce({ customItems: ['output-styles'] })
-        .mockResolvedValueOnce({ confirm: false })
+        // promptBoolean will return false by default
 
       await uninstall()
 
@@ -266,7 +276,7 @@ describe('uninstall command - Edge Cases', () => {
     it('should handle invalid mode', async () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: false })
+        // promptBoolean will return false by default
 
       const options: UninstallOptions = {
         mode: 'invalid' as any,
@@ -319,7 +329,7 @@ describe('uninstall command - Edge Cases', () => {
       mockUninstallerInstance.completeUninstall.mockRejectedValue(new Error('Complete uninstall failed'))
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
       mockErrorHandler.handleExitPromptError.mockReturnValue(false)
 
       await uninstall()
@@ -334,7 +344,7 @@ describe('uninstall command - Edge Cases', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'custom' })
         .mockResolvedValueOnce({ customItems: ['output-styles'] })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
       mockErrorHandler.handleExitPromptError.mockReturnValue(false)
 
       await uninstall()
@@ -355,7 +365,7 @@ describe('uninstall command - Edge Cases', () => {
       })
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       await uninstall()
 
@@ -374,7 +384,7 @@ describe('uninstall command - Edge Cases', () => {
       })
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       await uninstall()
 
@@ -402,7 +412,7 @@ describe('uninstall command - Edge Cases', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'custom' })
         .mockResolvedValueOnce({ customItems: ['output-styles', 'commands'] })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       await uninstall()
 
@@ -424,7 +434,7 @@ describe('uninstall command - Edge Cases', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'custom' })
         .mockResolvedValueOnce({ customItems: ['output-styles'] })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       // Clear previous calls to i18n.t
       mockI18n.i18n.t.mockClear()
@@ -447,7 +457,7 @@ describe('uninstall command - Edge Cases', () => {
 
     it('should handle empty results gracefully', async () => {
       mockUninstallerInstance.customUninstall.mockResolvedValue([])
-      mockInquirer.prompt.mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       const options: UninstallOptions = {
         mode: 'custom',
@@ -465,7 +475,7 @@ describe('uninstall command - Edge Cases', () => {
     it('should use i18n for all user-facing messages', async () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // confirm
 
       mockUninstallerInstance.completeUninstall.mockResolvedValue({
         success: true,
@@ -491,7 +501,7 @@ describe('uninstall command - Edge Cases', () => {
     it('should use addNumbersToChoices for main menu', async () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
-        .mockResolvedValueOnce({ confirm: false })
+        // promptBoolean will return false by default
 
       await uninstall()
 

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -1,11 +1,15 @@
 import type { UninstallOptions } from '../../src/commands/uninstall'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { uninstall } from '../../src/commands/uninstall'
+import { promptBoolean } from '../../src/utils/toggle-prompt'
 
 // Mock dependencies
 vi.mock('inquirer')
 vi.mock('../../src/i18n')
 vi.mock('../../src/utils/uninstaller')
+vi.mock('../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
+}))
 
 // Mock modules
 const mockInquirer = vi.hoisted(() => ({
@@ -23,6 +27,11 @@ const mockUninstaller = vi.hoisted(() => ({
   })),
 }))
 
+const mockedPromptBoolean = vi.mocked(promptBoolean)
+function queuePromptBooleans(...values: boolean[]) {
+  values.forEach(value => mockedPromptBoolean.mockResolvedValueOnce(value))
+}
+
 vi.mocked(await import('inquirer')).default = mockInquirer as any
 vi.mocked(await import('../../src/i18n')).i18n = mockI18n as any
 vi.mocked(await import('../../src/utils/uninstaller')).ZcfUninstaller = mockUninstaller.ZcfUninstaller
@@ -30,6 +39,13 @@ vi.mocked(await import('../../src/utils/uninstaller')).ZcfUninstaller = mockUnin
 describe('uninstall command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockedPromptBoolean.mockReset()
+    mockedPromptBoolean.mockResolvedValue(false)
+    mockInquirer.prompt.mockReset()
+    mockUninstaller.ZcfUninstaller.mockImplementation(() => ({
+      completeUninstall: vi.fn().mockResolvedValue({ success: true, removed: [], errors: [], warnings: [] }),
+      customUninstall: vi.fn().mockResolvedValue([{ success: true, removed: [], errors: [], warnings: [] }]),
+    }))
   })
 
   describe('interactive mode', () => {
@@ -38,6 +54,7 @@ describe('uninstall command', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
         .mockResolvedValueOnce({ confirm: true }) // Mock confirmation
+      queuePromptBooleans(true)
 
       await uninstall()
 
@@ -68,6 +85,7 @@ describe('uninstall command', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
         .mockResolvedValueOnce({ confirm: true })
+      queuePromptBooleans(true)
 
       await uninstall()
 
@@ -79,6 +97,7 @@ describe('uninstall command', () => {
         .mockResolvedValueOnce({ mainChoice: 'custom' })
         .mockResolvedValueOnce({ customItems: ['output-styles', 'commands'] })
         .mockResolvedValueOnce({ confirm: true })
+      queuePromptBooleans(true)
 
       const mockCustomUninstall = vi.fn().mockResolvedValue([
         { success: true, removed: [], errors: [], warnings: [] },
@@ -147,6 +166,8 @@ describe('uninstall command', () => {
         mode: 'complete',
       }
 
+      queuePromptBooleans(true)
+
       await uninstall(options)
 
       expect(mockCompleteUninstall).toHaveBeenCalled()
@@ -168,6 +189,8 @@ describe('uninstall command', () => {
         mode: 'custom',
         items: ['output-styles', 'commands'],
       }
+
+      queuePromptBooleans(true)
 
       await uninstall(options)
 
@@ -195,6 +218,8 @@ describe('uninstall command', () => {
         mode: 'complete',
       }
 
+      queuePromptBooleans(true)
+
       await uninstall(options)
 
       expect(mockCompleteUninstall).toHaveBeenCalled()
@@ -204,6 +229,7 @@ describe('uninstall command', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
         .mockResolvedValueOnce({ confirm: true })
+      queuePromptBooleans(true)
 
       await uninstall()
 
@@ -252,6 +278,7 @@ describe('uninstall command', () => {
       mockInquirer.prompt
         .mockResolvedValueOnce({ mainChoice: 'complete' })
         .mockResolvedValueOnce({ confirm: true })
+      queuePromptBooleans(true)
 
       await uninstall()
 

--- a/tests/unit/commands/init.edge.test.ts
+++ b/tests/unit/commands/init.edge.test.ts
@@ -10,6 +10,7 @@ import { configureApiCompletely } from '../../../src/utils/config-operations'
 import { getInstallationStatus, installClaudeCode, isClaudeCodeInstalled } from '../../../src/utils/installer'
 import { isTermux, isWindows } from '../../../src/utils/platform'
 import { resolveAiOutputLanguage, resolveTemplateLanguage } from '../../../src/utils/prompts'
+import { promptBoolean } from '../../../src/utils/toggle-prompt'
 import { selectAndInstallWorkflows } from '../../../src/utils/workflow-installer'
 import { readZcfConfig } from '../../../src/utils/zcf-config'
 
@@ -99,6 +100,10 @@ vi.mock('../../../src/utils/version-checker', () => ({
   checkClaudeCodeVersionAndPrompt: vi.fn(),
 }))
 
+vi.mock('../../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
+}))
+
 vi.mock('../../../src/utils/error-handler', () => ({
   handleExitPromptError: vi.fn(),
   handleGeneralError: vi.fn(),
@@ -131,6 +136,7 @@ interface TestMocks {
   selectAndInstallWorkflows: any
   configureApiCompletely: any
   inquirerPrompt: any
+  promptBoolean: any
 }
 
 let testMocks: TestMocks
@@ -155,6 +161,7 @@ describe('init - Edge Cases', () => {
       selectAndInstallWorkflows: selectAndInstallWorkflows as any,
       configureApiCompletely: configureApiCompletely as any,
       inquirerPrompt: inquirer.prompt as any,
+      promptBoolean: promptBoolean as any,
     }
 
     // Set default mock values
@@ -168,6 +175,7 @@ describe('init - Edge Cases', () => {
     testMocks.resolveTemplateLanguage.mockResolvedValue('en')
     testMocks.isTermux.mockReturnValue(false)
     testMocks.isWindows.mockReturnValue(false)
+    testMocks.promptBoolean.mockResolvedValue(false)
   })
 
   describe('validateSkipPromptOptions function edge cases', () => {
@@ -231,8 +239,7 @@ describe('init - Edge Cases', () => {
         localPath: '/Users/test/.claude/local/claude',
       })
       testMocks.resolveTemplateLanguage.mockResolvedValue('en') // language selection
-      testMocks.inquirerPrompt
-        .mockResolvedValueOnce({ shouldInstall: false }) // decline installation
+      testMocks.promptBoolean.mockResolvedValueOnce(false)
 
       await init({ skipPrompt: false })
 

--- a/tests/unit/commands/init.test.ts
+++ b/tests/unit/commands/init.test.ts
@@ -98,6 +98,9 @@ vi.mock('../../../src/i18n', async (importOriginal) => {
 vi.mock('../../../src/utils/mcp-selector', () => ({
   selectMcpServices: vi.fn(),
 }))
+vi.mock('../../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
+}))
 
 vi.mock('../../../src/utils/workflow-installer', () => ({
   selectAndInstallWorkflows: vi.fn(),
@@ -154,6 +157,7 @@ interface TestMocks {
   updateZcfConfig: any
   existsSync: any
   inquirerPrompt: any
+  promptBoolean: any
   readZcfConfig: any
   getExistingApiConfig: any
   switchToOfficialLogin: any
@@ -189,6 +193,7 @@ describe('init command', () => {
     const { configureApiCompletely, modifyApiConfigPartially } = await import('../../../src/utils/config-operations')
     const { configureIncrementalManagement } = await import('../../../src/utils/claude-code-incremental-manager')
     const { existsSync } = await import('node:fs')
+    const { promptBoolean } = await import('../../../src/utils/toggle-prompt')
 
     testMocks = {
       resolveAiOutputLanguage: vi.mocked(resolveAiOutputLanguage),
@@ -215,7 +220,10 @@ describe('init command', () => {
       configureApiCompletely: vi.mocked(configureApiCompletely),
       modifyApiConfigPartially: vi.mocked(modifyApiConfigPartially),
       configureIncrementalManagement: vi.mocked(configureIncrementalManagement),
+      promptBoolean: vi.mocked(promptBoolean),
     }
+    // Default promptBoolean to return false to avoid hanging
+    testMocks.promptBoolean.mockResolvedValue(false)
   })
 
   it('should load init module', async () => {
@@ -324,8 +332,8 @@ describe('init command', () => {
         testMocks.existsSync.mockReturnValue(false)
         testMocks.resolveTemplateLanguage.mockResolvedValue('zh-CN')
         testMocks.inquirerPrompt
-          .mockResolvedValueOnce({ shouldInstall: true })
           .mockResolvedValueOnce({ shouldConfigureMcp: false })
+        testMocks.promptBoolean.mockResolvedValueOnce(true) // shouldInstall
         testMocks.resolveAiOutputLanguage.mockResolvedValue('chinese-simplified')
         testMocks.selectAndInstallWorkflows.mockResolvedValue(undefined)
         testMocks.configureOutputStyle.mockResolvedValue(undefined)

--- a/tests/unit/commands/menu.test.ts
+++ b/tests/unit/commands/menu.test.ts
@@ -70,6 +70,10 @@ vi.mock('../../../src/utils/error-handler', () => ({
   handleGeneralError: vi.fn(),
 }))
 
+vi.mock('../../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
+}))
+
 // Mock i18n system
 vi.mock('../../../src/i18n', () => ({
   initI18n: vi.fn().mockResolvedValue(undefined),
@@ -83,11 +87,20 @@ vi.mock('../../../src/i18n', () => ({
 }))
 
 describe('menu command', () => {
+  let mockedPromptBoolean: ReturnType<typeof vi.fn>
+  const queuePromptBooleans = (...values: boolean[]) => {
+    values.forEach(value => mockedPromptBoolean.mockResolvedValueOnce(value))
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
+    const togglePromptModule = await import('../../../src/utils/toggle-prompt')
+    mockedPromptBoolean = vi.mocked(togglePromptModule.promptBoolean)
+    mockedPromptBoolean.mockReset()
+    mockedPromptBoolean.mockResolvedValue(false)
 
     // Initialize i18n for test environment
     const { initI18n } = await import('../../../src/i18n')
@@ -152,7 +165,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'zh-CN', codeToolType: 'claude-code' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '1' })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(false)
       vi.mocked(init).mockResolvedValue(undefined)
 
       await showMainMenu()
@@ -168,7 +181,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'zh-CN', codeToolType: 'claude-code' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '3' })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(false)
       vi.mocked(configureApiFeature).mockResolvedValue(undefined)
 
       await showMainMenu()
@@ -184,7 +197,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'zh-CN', codeToolType: 'claude-code' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '4' })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(false)
       vi.mocked(configureMcpFeature).mockResolvedValue(undefined)
 
       await showMainMenu()
@@ -216,7 +229,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfigAsync).mockResolvedValue({ preferredLang: 'zh-CN', codeToolType: 'claude-code' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: 'u' })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(false)
       vi.mocked(runCcusageFeature).mockResolvedValue(undefined)
 
       await showMainMenu()
@@ -232,7 +245,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfigAsync).mockResolvedValue({ preferredLang: 'en', codeToolType: 'claude-code' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: 'u' })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(false)
       vi.mocked(runCcusageFeature).mockResolvedValue(undefined)
 
       await showMainMenu()
@@ -295,7 +308,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'en', codeToolType: 'codex' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '1' })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(false)
 
       await showMainMenu()
 
@@ -310,8 +323,7 @@ describe('menu command', () => {
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'en', codeToolType: 'codex' } as any)
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '-' })
-        .mockResolvedValueOnce({ confirm: true })
-        .mockResolvedValueOnce({ continue: false })
+      queuePromptBooleans(true, false)
 
       await showMainMenu()
 
@@ -462,8 +474,8 @@ describe('menu command', () => {
 
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'en', codeToolType: 'claude-code' } as any)
       vi.mocked(inquirer.prompt)
-        .mockResolvedValueOnce({ choice: '1' }) // Full initialization
-        .mockResolvedValueOnce({ continue: false }) // Don't continue after init
+        .mockResolvedValueOnce({ choice: '1' })
+      queuePromptBooleans(false)
 
       await showMainMenu()
 
@@ -477,8 +489,8 @@ describe('menu command', () => {
 
       vi.mocked(readZcfConfig).mockReturnValue({ preferredLang: 'en', codeToolType: 'codex' } as any)
       vi.mocked(inquirer.prompt)
-        .mockResolvedValueOnce({ choice: '1' }) // Full initialization
-        .mockResolvedValueOnce({ continue: false }) // Don't continue after init
+        .mockResolvedValueOnce({ choice: '1' })
+      queuePromptBooleans(false)
 
       await showMainMenu()
 

--- a/tests/unit/utils/code-tools/codex-uninstall-enhanced.test.ts
+++ b/tests/unit/utils/code-tools/codex-uninstall-enhanced.test.ts
@@ -1,6 +1,7 @@
 import type { CodexUninstallItem } from '../../../../src/utils/code-tools/codex-uninstaller'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCodexUninstall } from '../../../../src/utils/code-tools/codex'
+import { promptBoolean } from '../../../../src/utils/toggle-prompt'
 
 // Mock dependencies
 vi.mock('../../../../src/i18n', () => ({
@@ -45,6 +46,10 @@ const mockReadZcfConfig = vi.hoisted(() => vi.fn(() => ({
 } as any)))
 vi.mock('../../../../src/utils/zcf-config', () => ({
   readZcfConfig: mockReadZcfConfig,
+}))
+
+vi.mock('../../../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
 }))
 
 // Import mocked functions
@@ -100,7 +105,7 @@ describe('runCodexUninstall - Enhanced Version', () => {
     it('should prompt for uninstall mode selection', async () => {
       mockInquirerPrompt
         .mockResolvedValueOnce({ mode: 'complete' }) // Mode selection
-        .mockResolvedValueOnce({ confirm: true }) // Confirmation
+      vi.mocked(promptBoolean).mockResolvedValueOnce(true)
 
       mockUninstaller.completeUninstall.mockResolvedValue({
         success: true,
@@ -155,7 +160,7 @@ describe('runCodexUninstall - Enhanced Version', () => {
     it('should perform complete uninstall with confirmation', async () => {
       mockInquirerPrompt
         .mockResolvedValueOnce({ mode: 'complete' }) // Mode selection
-        .mockResolvedValueOnce({ confirm: true }) // Confirmation
+      vi.mocked(promptBoolean).mockResolvedValueOnce(true)
 
       const mockResult = {
         success: true,
@@ -169,12 +174,10 @@ describe('runCodexUninstall - Enhanced Version', () => {
 
       await runCodexUninstall()
 
-      expect(mockInquirerPrompt).toHaveBeenCalledWith([{
-        type: 'confirm',
-        name: 'confirm',
+      expect(promptBoolean).toHaveBeenCalledWith({
         message: 'mocked_codex:uninstallPrompt',
-        default: false,
-      }])
+        defaultValue: false,
+      })
 
       expect(mockUninstaller.completeUninstall).toHaveBeenCalledTimes(1)
       expect(mockConsoleLog).toHaveBeenCalledWith('mocked_codex:uninstallSuccess')
@@ -183,7 +186,7 @@ describe('runCodexUninstall - Enhanced Version', () => {
     it('should handle cancelled complete uninstall confirmation', async () => {
       mockInquirerPrompt
         .mockResolvedValueOnce({ mode: 'complete' }) // Mode selection
-        .mockResolvedValueOnce({ confirm: false }) // Cancelled confirmation
+      vi.mocked(promptBoolean).mockResolvedValueOnce(false)
 
       await runCodexUninstall()
 
@@ -194,7 +197,7 @@ describe('runCodexUninstall - Enhanced Version', () => {
     it('should display warnings and errors from complete uninstall', async () => {
       mockInquirerPrompt
         .mockResolvedValueOnce({ mode: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      vi.mocked(promptBoolean).mockResolvedValueOnce(true)
 
       const mockResult = {
         success: false,
@@ -306,7 +309,7 @@ describe('runCodexUninstall - Enhanced Version', () => {
     it('should handle complete uninstall execution failure', async () => {
       mockInquirerPrompt
         .mockResolvedValueOnce({ mode: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      vi.mocked(promptBoolean).mockResolvedValueOnce(true)
 
       mockUninstaller.completeUninstall.mockRejectedValue(new Error('Uninstall execution failed'))
 
@@ -328,7 +331,7 @@ describe('runCodexUninstall - Enhanced Version', () => {
     it('should report successful removals', async () => {
       mockInquirerPrompt
         .mockResolvedValueOnce({ mode: 'complete' })
-        .mockResolvedValueOnce({ confirm: true })
+      vi.mocked(promptBoolean).mockResolvedValueOnce(true)
 
       const mockResult = {
         success: true,

--- a/tests/utils/cometix/menu.test.ts
+++ b/tests/utils/cometix/menu.test.ts
@@ -32,13 +32,20 @@ vi.mock('../../../src/utils/error-handler', () => ({
   handleGeneralError: vi.fn(),
   handleExitPromptError: vi.fn(() => false),
 }))
+vi.mock('../../../src/utils/toggle-prompt', () => ({
+  promptBoolean: vi.fn(),
+}))
 
 describe('cCometixLine menu', () => {
   let consoleLogSpy: any
+  let mockedPromptBoolean: any
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    // Get mocked promptBoolean
+    const togglePromptModule = await import('../../../src/utils/toggle-prompt')
+    mockedPromptBoolean = vi.mocked(togglePromptModule.promptBoolean)
   })
 
   afterEach(() => {
@@ -67,7 +74,7 @@ describe('cCometixLine menu', () => {
     it('should handle install or update option (choice 1)', async () => {
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '1' })
-        .mockResolvedValueOnce({ continueInCometix: false })
+      mockedPromptBoolean.mockResolvedValueOnce(false) // continueInCometix
 
       vi.mocked(installer.installCometixLine).mockResolvedValue()
 
@@ -80,7 +87,7 @@ describe('cCometixLine menu', () => {
     it('should handle print config option (choice 2)', async () => {
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '2' })
-        .mockResolvedValueOnce({ continueInCometix: false })
+      mockedPromptBoolean.mockResolvedValueOnce(false) // continueInCometix
 
       vi.mocked(commands.runCometixPrintConfig).mockResolvedValue()
 
@@ -93,7 +100,7 @@ describe('cCometixLine menu', () => {
     it('should handle custom config TUI option (choice 3)', async () => {
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '3' })
-        .mockResolvedValueOnce({ continueInCometix: false })
+      mockedPromptBoolean.mockResolvedValueOnce(false) // continueInCometix
 
       vi.mocked(commands.runCometixTuiConfig).mockResolvedValue()
 
@@ -139,14 +146,15 @@ describe('cCometixLine menu', () => {
     it('should handle continue in menu flow', async () => {
       vi.mocked(inquirer.prompt)
         .mockResolvedValueOnce({ choice: '1' })
-        .mockResolvedValueOnce({ continueInCometix: true })
         .mockResolvedValueOnce({ choice: '0' })
+      mockedPromptBoolean.mockResolvedValueOnce(true) // continueInCometix
 
       vi.mocked(installer.installCometixLine).mockResolvedValue()
 
       await showCometixMenu()
 
-      expect(inquirer.prompt).toHaveBeenCalledTimes(3)
+      expect(inquirer.prompt).toHaveBeenCalledTimes(2)
+      expect(mockedPromptBoolean).toHaveBeenCalledTimes(1)
       expect(installer.installCometixLine).toHaveBeenCalledTimes(1)
     })
 


### PR DESCRIPTION
## Description

This PR introduces the `inquirer-toggle` package and refactors boolean prompts across the codebase to use a consistent toggle interface. The changes improve user experience by providing a more intuitive boolean selection mechanism and centralize prompt logic for better maintainability.

### Key Changes:

- New feature: Added `inquirer-toggle` package for enhanced boolean prompts
- Code refactoring: Centralized boolean prompt logic in `toggle-prompt.ts`
- User experience: Improved boolean selection interface across all commands
- Test updates: Comprehensive test coverage for new toggle prompt functionality

### Files Modified:

- `package.json` - Added inquirer-toggle dependency
- `pnpm-lock.yaml` - Updated lockfile
- `pnpm-workspace.yaml` - Workspace configuration update
- `src/utils/toggle-prompt.ts` - New toggle prompt utility module
- `src/commands/init.ts` - Refactored to use toggle prompts
- `src/commands/menu.ts` - Updated boolean prompts
- `src/commands/uninstall.ts` - Refactored prompts
- `src/utils/prompts.ts` - Simplified prompt logic
- Multiple utility files updated to use new toggle prompt system
- Comprehensive test updates across 20+ test files

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Code changes tested
- [x] No new warnings introduced
- [x] Code follows style guidelines
- [x] Tests added/updated

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Code follows project guidelines

## Additional Information

**Branch:** `feat/boolean-toggle` → `main`
**Commits:** 1
**Files Changed:** 36
**Lines Added:** 692
**Lines Removed:** 498

### Commit History:

```
51dae98 feat: add inquirer-toggle package and refactor prompts
```

### Summary

This PR standardizes boolean prompts across the ZCF CLI by introducing the `inquirer-toggle` package and creating a centralized `toggle-prompt.ts` utility. The refactoring improves code maintainability and provides a better user experience with intuitive toggle-based boolean selection.

---
🤖 Generated with /zcf-pr command
