### PR TITLE
feat: implement extra fields preservation in Codex MCP configuration

### DIFF
--- a/.claude/plan/codex-mcp-extra-fields-preservation.md
+++ b/.claude/plan/codex-mcp-extra-fields-preservation.md
@@ -1,0 +1,155 @@
+# Codex MCP Extra Fields Preservation Plan
+
+**Created**: 2025-11-25
+**Status**: In Progress
+**Priority**: High
+
+## 📋 Task Overview
+
+Fix the issue where Codex configuration updates unexpectedly clear extra MCP configuration fields (e.g., `startup_timeout_sec = 30`).
+
+### Problem Description
+
+Users reported that when updating Codex configurations, additional MCP configuration fields beyond the standard ones managed by ZCF are being cleared. This includes fields like:
+- `startup_timeout_sec`
+- `retries`
+- `max_connections`
+- Any custom configuration fields
+
+### Root Cause
+
+The `parseCodexConfig` and `renderCodexConfig` functions only handle known fields:
+- `command`
+- `args`
+- `env`
+- `startup_timeout_ms`
+
+Any additional fields are ignored during parsing and not written back during rendering.
+
+## 🎯 Solution Approach
+
+Implement **Type-Safe Extra Fields Support** by:
+1. Adding an `extraFields` property to `CodexMcpService` interface
+2. Collecting unknown fields during parsing
+3. Outputting extra fields during rendering
+4. Maintaining backward compatibility
+
+## 📝 Implementation Steps
+
+### Step 1: Enhance Type Definition
+**File**: `src/utils/code-tools/codex.ts:42-48`
+
+```typescript
+export interface CodexMcpService {
+  id: string
+  command: string
+  args: string[]
+  env?: Record<string, string>
+  startup_timeout_ms?: number
+  // NEW: Preserve all extra configuration fields
+  extraFields?: Record<string, any>
+}
+```
+
+### Step 2: Modify parseCodexConfig Function
+**File**: `src/utils/code-tools/codex.ts:268-280`
+
+- Define known fields set
+- Collect extra fields during MCP parsing
+- Store extra fields in service object
+
+### Step 3: Create TOML Field Formatter
+**File**: `src/utils/code-tools/codex.ts` (new helper function)
+
+- Handle string, number, boolean types
+- Handle arrays and objects
+- Proper TOML escaping and formatting
+
+### Step 4: Modify renderCodexConfig Function
+**File**: `src/utils/code-tools/codex.ts:515-547`
+
+- Output known fields first
+- Output extra fields using formatter
+- Maintain field order and formatting
+
+### Step 5: Write Unit Tests
+**File**: `tests/utils/code-tools/codex-extra-fields.test.ts`
+
+Test cases:
+- Basic extra field preservation
+- Round-trip consistency (parse → render → parse)
+- Complex field types (arrays, objects)
+- Multiple MCP services with different extra fields
+
+### Step 6: Write Edge Case Tests
+**File**: `tests/utils/code-tools/codex-extra-fields.edge.test.ts`
+
+Test cases:
+- Empty extra fields (should not add field)
+- Special characters handling
+- Config update scenarios
+- Null/undefined values
+
+### Step 7: Update Documentation
+**Files**: `CLAUDE.md`, `README.md`
+
+- Document extra fields support
+- Provide usage examples
+- Update version history
+
+## ✅ Success Criteria
+
+### Functional
+- [ ] All extra fields collected during parsing
+- [ ] Extra fields correctly formatted in output
+- [ ] Round-trip consistency maintained
+- [ ] All TOML types supported
+
+### Testing
+- [ ] Unit test coverage ≥ 80%
+- [ ] All edge cases covered
+- [ ] All tests passing
+- [ ] Real config file tested
+
+### Quality
+- [ ] TypeScript type checks pass
+- [ ] ESLint checks pass
+- [ ] Follows KISS/YAGNI/DRY principles
+- [ ] Documentation complete
+
+## 🔄 Implementation Progress
+
+- [x] Planning complete
+- [ ] Step 1: Type definition
+- [ ] Step 2: Parse logic
+- [ ] Step 3: Helper function
+- [ ] Step 4: Render logic
+- [ ] Step 5: Unit tests
+- [ ] Step 6: Edge tests
+- [ ] Step 7: Documentation
+
+## 📊 Impact Analysis
+
+| Module | Impact | Change Type | Risk |
+|--------|--------|-------------|------|
+| Type definition | Medium | Add optional field | Low |
+| parseCodexConfig | High | Logic enhancement | Medium |
+| renderCodexConfig | High | Logic enhancement | Medium |
+| Helper function | Low | New function | Low |
+| Tests | High | New tests | None |
+| Documentation | Low | Content update | None |
+
+## ⚠️ Risk Mitigation
+
+1. **TOML Compatibility**: Use unified formatter with thorough testing
+2. **Backward Compatibility**: Optional field, no breaking changes
+3. **Performance**: Minimal impact, extra fields typically few
+
+## 🎯 Acceptance Checklist
+
+- [ ] All known fields work as before
+- [ ] Extra fields preserved across updates
+- [ ] All test cases pass
+- [ ] Documentation updated
+- [ ] Code review completed
+- [ ] User feedback validated

--- a/tests/unit/utils/code-tools/codex-extra-fields.edge.test.ts
+++ b/tests/unit/utils/code-tools/codex-extra-fields.edge.test.ts
@@ -1,0 +1,534 @@
+import type { CodexConfigData } from '../../../../src/utils/code-tools/codex'
+import { describe, expect, it } from 'vitest'
+import { parseCodexConfig, renderCodexConfig } from '../../../../src/utils/code-tools/codex'
+
+describe('codex MCP Extra Fields - Edge Cases', () => {
+  describe('empty and Null Values', () => {
+    it('should skip null extra field values during rendering', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            null_field: null,
+            valid_field: 'value',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).not.toContain('null_field')
+      expect(rendered).toContain('valid_field = "value"')
+    })
+
+    it('should skip undefined extra field values during rendering', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            undefined_field: undefined,
+            valid_field: 'value',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).not.toContain('undefined_field')
+      expect(rendered).toContain('valid_field = "value"')
+    })
+
+    it('should handle empty string values', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            empty_string: '',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('empty_string = ""')
+    })
+
+    it('should handle empty arrays', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            empty_array: [],
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('empty_array = []')
+    })
+
+    it('should handle empty objects', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            empty_object: {},
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('empty_object = {}')
+    })
+  })
+
+  describe('special Characters Handling', () => {
+    it('should normalize backslashes to forward slashes in string values', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            path: 'C:\\Windows\\System32',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      // normalizeTomlPath converts backslashes to forward slashes
+      expect(rendered).toContain('path = "C:/Windows/System32"')
+
+      // Verify round-trip - path will be normalized
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.path).toBe('C:/Windows/System32')
+    })
+
+    it('should escape quotes in string values', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            description: 'Test "quoted" value',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('description = "Test \\"quoted\\" value"')
+
+      // Verify round-trip
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.description).toBe('Test "quoted" value')
+    })
+
+    it('should handle newlines in string values', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+multiline = "line1\\nline2\\nline3"
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices[0].extraFields?.multiline).toContain('line1')
+      expect(config.mcpServices[0].extraFields?.multiline).toContain('line2')
+    })
+
+    it('should normalize paths in array elements', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            paths: ['C:\\Windows', 'D:\\Program Files', 'E:\\Data'],
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      // normalizeTomlPath converts backslashes to forward slashes
+      expect(rendered).toContain('paths = ["C:/Windows", "D:/Program Files", "E:/Data"]')
+    })
+  })
+
+  describe('numeric Edge Cases', () => {
+    it('should handle zero values', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            zero_value: 0,
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('zero_value = 0')
+
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.zero_value).toBe(0)
+    })
+
+    it('should handle negative numbers', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            negative: -42,
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('negative = -42')
+
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.negative).toBe(-42)
+    })
+
+    it('should handle floating point numbers', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            float_value: 3.14159,
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('float_value = 3.14159')
+
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.float_value).toBeCloseTo(3.14159)
+    })
+
+    it('should handle very large numbers', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            large_number: 9007199254740991, // Number.MAX_SAFE_INTEGER
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('large_number = 9007199254740991')
+
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.large_number).toBe(9007199254740991)
+    })
+  })
+
+  describe('boolean Edge Cases', () => {
+    it('should handle false boolean values', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            disabled: false,
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('disabled = false')
+
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.disabled).toBe(false)
+    })
+  })
+
+  describe('complex Nested Structures', () => {
+    it('should handle nested objects in inline tables', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+config = {server = {host = "localhost", port = 8080}}
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices[0].extraFields?.config).toBeDefined()
+      expect(config.mcpServices[0].extraFields?.config.server).toBeDefined()
+      expect(config.mcpServices[0].extraFields?.config.server.host).toBe('localhost')
+      expect(config.mcpServices[0].extraFields?.config.server.port).toBe(8080)
+    })
+
+    it('should preserve nested objects through round-trip (parse → render → parse)', () => {
+      // This test ensures nested inline tables don't become [object Object]
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+config = {server = {host = "localhost", port = 8080}}
+`
+      const config = parseCodexConfig(toml)
+      const rendered = renderCodexConfig(config)
+
+      // Verify no [object Object] in rendered output
+      expect(rendered).not.toContain('[object Object]')
+
+      // Verify nested structure is preserved in rendered TOML
+      expect(rendered).toContain('config = {server = {host =')
+
+      // Verify round-trip preserves data
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.config.server.host).toBe('localhost')
+      expect(reparsed.mcpServices[0].extraFields?.config.server.port).toBe(8080)
+    })
+
+    it('should handle deeply nested objects (3+ levels)', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+deep = {level1 = {level2 = {level3 = "value"}}}
+`
+      const config = parseCodexConfig(toml)
+      const rendered = renderCodexConfig(config)
+
+      // Verify no [object Object]
+      expect(rendered).not.toContain('[object Object]')
+
+      // Verify round-trip
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.deep.level1.level2.level3).toBe('value')
+    })
+
+    it('should handle arrays with mixed types', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+mixed_array = [1, 2, 3]
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices[0].extraFields?.mixed_array).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('field Name Edge Cases', () => {
+    it('should handle field names with underscores', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            field_with_underscores: 'value',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('field_with_underscores = "value"')
+    })
+
+    it('should handle field names with numbers', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            field123: 'value',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('field123 = "value"')
+    })
+  })
+
+  describe('multiple Services with Extra Fields', () => {
+    it('should handle multiple services each with different extra fields', () => {
+      const toml = `
+[mcp_servers.service1]
+command = "node"
+args = []
+custom1 = "value1"
+timeout1 = 30
+
+[mcp_servers.service2]
+command = "python"
+args = []
+custom2 = "value2"
+retries2 = 5
+
+[mcp_servers.service3]
+command = "java"
+args = []
+custom3 = "value3"
+max_conn3 = 100
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices).toHaveLength(3)
+      expect(config.mcpServices[0].extraFields?.custom1).toBe('value1')
+      expect(config.mcpServices[0].extraFields?.timeout1).toBe(30)
+      expect(config.mcpServices[1].extraFields?.custom2).toBe('value2')
+      expect(config.mcpServices[1].extraFields?.retries2).toBe(5)
+      expect(config.mcpServices[2].extraFields?.custom3).toBe('value3')
+      expect(config.mcpServices[2].extraFields?.max_conn3).toBe(100)
+
+      // Verify round-trip
+      const rendered = renderCodexConfig(config)
+      const reparsed = parseCodexConfig(rendered)
+
+      expect(reparsed.mcpServices[0].extraFields).toEqual(config.mcpServices[0].extraFields)
+      expect(reparsed.mcpServices[1].extraFields).toEqual(config.mcpServices[1].extraFields)
+      expect(reparsed.mcpServices[2].extraFields).toEqual(config.mcpServices[2].extraFields)
+    })
+  })
+
+  describe('stress Tests', () => {
+    it('should handle many extra fields', () => {
+      const extraFields: Record<string, any> = {}
+      for (let i = 0; i < 50; i++) {
+        extraFields[`field${i}`] = `value${i}`
+      }
+
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields,
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+      const reparsed = parseCodexConfig(rendered)
+
+      expect(Object.keys(reparsed.mcpServices[0].extraFields || {})).toHaveLength(50)
+      expect(reparsed.mcpServices[0].extraFields).toEqual(extraFields)
+    })
+
+    it('should handle very long string values', () => {
+      const longString = 'a'.repeat(1000)
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            long_field: longString,
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+      const reparsed = parseCodexConfig(rendered)
+
+      expect(reparsed.mcpServices[0].extraFields?.long_field).toBe(longString)
+    })
+  })
+})

--- a/tests/unit/utils/code-tools/codex-extra-fields.test.ts
+++ b/tests/unit/utils/code-tools/codex-extra-fields.test.ts
@@ -1,0 +1,294 @@
+import type { CodexConfigData } from '../../../../src/utils/code-tools/codex'
+import { describe, expect, it } from 'vitest'
+import { parseCodexConfig, renderCodexConfig } from '../../../../src/utils/code-tools/codex'
+
+describe('codex MCP Extra Fields Preservation', () => {
+  describe('parseCodexConfig - Extra Fields Collection', () => {
+    it('should preserve extra MCP fields during parsing', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = ["server.js"]
+startup_timeout_sec = 30
+retries = 3
+max_connections = 100
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices).toHaveLength(1)
+      expect(config.mcpServices[0].extraFields).toBeDefined()
+      expect(config.mcpServices[0].extraFields?.startup_timeout_sec).toBe(30)
+      expect(config.mcpServices[0].extraFields?.retries).toBe(3)
+      expect(config.mcpServices[0].extraFields?.max_connections).toBe(100)
+    })
+
+    it('should not add extraFields when no extra fields exist', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+startup_timeout_ms = 5000
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices).toHaveLength(1)
+      expect(config.mcpServices[0].extraFields).toBeUndefined()
+    })
+
+    it('should handle multiple MCP services with different extra fields', () => {
+      const toml = `
+[mcp_servers.service1]
+command = "node"
+args = ["server1.js"]
+custom_field1 = "value1"
+
+[mcp_servers.service2]
+command = "python"
+args = ["server2.py"]
+custom_field2 = 42
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices).toHaveLength(2)
+      expect(config.mcpServices[0].extraFields?.custom_field1).toBe('value1')
+      expect(config.mcpServices[1].extraFields?.custom_field2).toBe(42)
+    })
+
+    it('should handle complex extra field types', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+string_field = "test"
+number_field = 123
+boolean_field = true
+array_field = ["a", "b", "c"]
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices[0].extraFields?.string_field).toBe('test')
+      expect(config.mcpServices[0].extraFields?.number_field).toBe(123)
+      expect(config.mcpServices[0].extraFields?.boolean_field).toBe(true)
+      expect(config.mcpServices[0].extraFields?.array_field).toEqual(['a', 'b', 'c'])
+    })
+
+    it('should handle object type extra fields', () => {
+      const toml = `
+[mcp_servers.test]
+command = "node"
+args = []
+object_field = {key1 = "value1", key2 = 42}
+`
+      const config = parseCodexConfig(toml)
+
+      expect(config.mcpServices[0].extraFields?.object_field).toEqual({
+        key1: 'value1',
+        key2: 42,
+      })
+    })
+  })
+
+  describe('renderCodexConfig - Extra Fields Output', () => {
+    it('should output extra fields correctly', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: ['server.js'],
+          extraFields: {
+            startup_timeout_sec: 30,
+            retries: 3,
+            custom_setting: 'important',
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('[mcp_servers.test]')
+      expect(rendered).toContain('command = "node"')
+      expect(rendered).toContain('args = ["server.js"]')
+      expect(rendered).toContain('startup_timeout_sec = 30')
+      expect(rendered).toContain('retries = 3')
+      expect(rendered).toContain('custom_setting = "important"')
+    })
+
+    it('should not output extraFields section when undefined', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('[mcp_servers.test]')
+      expect(rendered).toContain('command = "node"')
+      // Should not have any extra fields
+      expect(rendered.split('\n').filter(line => line.includes('=')).length).toBe(2) // Only command and args
+    })
+
+    it('should format different value types correctly', () => {
+      const config: CodexConfigData = {
+        model: null,
+        modelProvider: null,
+        providers: [],
+        mcpServices: [{
+          id: 'test',
+          command: 'node',
+          args: [],
+          extraFields: {
+            string_val: 'test',
+            number_val: 42,
+            boolean_val: true,
+            array_val: ['a', 'b'],
+          },
+        }],
+        managed: true,
+      }
+
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('string_val = "test"')
+      expect(rendered).toContain('number_val = 42')
+      expect(rendered).toContain('boolean_val = true')
+      expect(rendered).toContain('array_val = ["a", "b"]')
+    })
+  })
+
+  describe('round-trip Consistency', () => {
+    it('should maintain extra fields through parse → render → parse cycle', () => {
+      const originalToml = `
+[mcp_servers.test]
+command = "node"
+args = ["server.js"]
+startup_timeout_ms = 5000
+custom_field = "value"
+numeric_field = 42
+boolean_field = true
+`
+
+      const config = parseCodexConfig(originalToml)
+      const rendered = renderCodexConfig(config)
+      const reparsed = parseCodexConfig(rendered)
+
+      expect(reparsed.mcpServices[0].extraFields).toEqual(
+        config.mcpServices[0].extraFields,
+      )
+    })
+
+    it('should preserve extra fields during config updates', () => {
+      // Simulate initial configuration
+      const initial = parseCodexConfig(`
+[mcp_servers.serena]
+command = "npx"
+args = ["-y", "@serena/mcp-serena"]
+startup_timeout_sec = 30
+custom_setting = "important"
+`)
+
+      // Simulate adding new provider (not modifying MCP)
+      const updated: CodexConfigData = {
+        ...initial,
+        providers: [
+          {
+            id: 'new-provider',
+            name: 'New',
+            baseUrl: 'https://api.example.com',
+            wireApi: 'responses',
+            envKey: 'NEW_KEY',
+            requiresOpenaiAuth: true,
+          },
+        ],
+      }
+
+      // Render and reparse
+      const rendered = renderCodexConfig(updated)
+      const final = parseCodexConfig(rendered)
+
+      // Verify extra fields not lost
+      expect(final.mcpServices[0].extraFields?.startup_timeout_sec).toBe(30)
+      expect(final.mcpServices[0].extraFields?.custom_setting).toBe('important')
+    })
+
+    it('should handle multiple round-trips without data loss', () => {
+      const originalToml = `
+[mcp_servers.test]
+command = "node"
+args = []
+field1 = "value1"
+field2 = 123
+field3 = true
+`
+
+      let config = parseCodexConfig(originalToml)
+
+      // Perform 3 round-trips
+      for (let i = 0; i < 3; i++) {
+        const rendered = renderCodexConfig(config)
+        config = parseCodexConfig(rendered)
+      }
+
+      // Verify data integrity after multiple round-trips
+      expect(config.mcpServices[0].extraFields?.field1).toBe('value1')
+      expect(config.mcpServices[0].extraFields?.field2).toBe(123)
+      expect(config.mcpServices[0].extraFields?.field3).toBe(true)
+    })
+  })
+
+  describe('real-world Scenarios', () => {
+    it('should preserve user-reported startup_timeout_sec field', () => {
+      const toml = `
+[mcp_servers.serena]
+command = "npx"
+args = ["-y", "@serena/mcp-serena"]
+startup_timeout_sec = 30
+`
+      const config = parseCodexConfig(toml)
+      const rendered = renderCodexConfig(config)
+
+      expect(rendered).toContain('startup_timeout_sec = 30')
+
+      // Verify it survives round-trip
+      const reparsed = parseCodexConfig(rendered)
+      expect(reparsed.mcpServices[0].extraFields?.startup_timeout_sec).toBe(30)
+    })
+
+    it('should handle mixed known and extra fields', () => {
+      const toml = `
+[mcp_servers.complex]
+command = "node"
+args = ["server.js"]
+env = {PATH = "/usr/bin", HOME = "/home/user"}
+startup_timeout_ms = 5000
+startup_timeout_sec = 30
+retries = 3
+max_connections = 100
+custom_config = "value"
+`
+      const config = parseCodexConfig(toml)
+
+      // Known fields should be in their proper places
+      expect(config.mcpServices[0].command).toBe('node')
+      expect(config.mcpServices[0].args).toEqual(['server.js'])
+      expect(config.mcpServices[0].env).toEqual({ PATH: '/usr/bin', HOME: '/home/user' })
+      expect(config.mcpServices[0].startup_timeout_ms).toBe(5000)
+
+      // Extra fields should be in extraFields
+      expect(config.mcpServices[0].extraFields?.startup_timeout_sec).toBe(30)
+      expect(config.mcpServices[0].extraFields?.retries).toBe(3)
+      expect(config.mcpServices[0].extraFields?.max_connections).toBe(100)
+      expect(config.mcpServices[0].extraFields?.custom_config).toBe('value')
+    })
+  })
+})


### PR DESCRIPTION
## Description / 变更概述

This PR merges the latest work from `fix/codex` into `main`, introducing Codex MCP extra-field preservation plus supporting docs and tests. | 本次 PR 将 `fix/codex` 的改动合入 `main`，新增 Codex MCP 额外字段保留能力以及对应文档与测试。

### Key Changes / 关键更新
- Preserve unknown/extra fields when rewriting Codex MCP configuration payloads to avoid user customizations being dropped during migrations.
- Document the preservation strategy in `.claude/plan/codex-mcp-extra-fields-preservation.md` for future maintainers.
- Add comprehensive unit & edge tests around the new preservation flow to cover real-world Codex configs.

### Files Modified / 影响文件
- `.claude/plan/codex-mcp-extra-fields-preservation.md`
- `src/utils/code-tools/codex.ts`
- `tests/unit/utils/code-tools/codex-extra-fields.edge.test.ts`
- `tests/unit/utils/code-tools/codex-extra-fields.test.ts`

## Type of Change / 变更类型
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing / 测试
- [ ] Code changes tested locally
- [x] No new warnings introduced
- [x] Code follows style guidelines
- [x] Tests added/updated

## Checklist / 自检清单
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Code follows project guidelines

## Additional Information / 其他信息
- Branch: `fix/codex` → `main`
- Commits: 1
- Files Changed: 4

### Commit History / 提交历史
```
c1ea0ef feat: implement extra fields preservation in Codex MCP configuration
```

---
🤖 Generated via /zcf-pr workflow
