### PR TITLE
fix(updater): add sudo support for Linux non-root users

### DIFF
--- a/src/i18n/locales/en/updater.json
+++ b/src/i18n/locales/en/updater.json
@@ -1,5 +1,6 @@
 {
   "autoUpdating": "Auto-updating {tool}...",
+  "usingSudo": "Detected non-root Linux user. Using sudo for update (password prompt may appear).",
   "cannotCheckVersion": "Cannot check latest version",
   "ccrNotInstalled": "CCR is not installed",
   "ccrUpToDate": "CCR is up to date (v{version})",

--- a/src/i18n/locales/zh-CN/updater.json
+++ b/src/i18n/locales/zh-CN/updater.json
@@ -1,5 +1,6 @@
 {
   "autoUpdating": "正在自动更新 {tool}...",
+  "usingSudo": "检测到 Linux 非 root 用户，正在使用 sudo 提升权限进行更新（可能需要输入密码）。",
   "cannotCheckVersion": "无法检查最新版本",
   "ccrNotInstalled": "CCR 未安装",
   "ccrUpToDate": "CCR 已是最新版本 (v{version})",


### PR DESCRIPTION
### **User description**
## Summary

- Add sudo support for npm global install commands on Linux non-root users
- Migrate from child_process to tinyexec for command execution
- Add comprehensive i18n messages for sudo usage notification

## Changes

### Core Changes
- **`src/utils/auto-updater.ts`**: 
  - Add `shouldUseSudoForGlobalInstall()` detection for Linux environments
  - Apply sudo prefix to npm update commands (CCR, CometixLine) and claude update for non-root Linux users
  - Homebrew installations continue to use brew without sudo
  - Migrate from `child_process.execSync` to `tinyexec` for better cross-platform support

### Internationalization
- **`src/i18n/locales/en/updater.json`**: Add English sudo usage message
- **`src/i18n/locales/zh-CN/updater.json`**: Add Chinese sudo usage message

### Tests
- **`tests/unit/utils/auto-updater.test.ts`**: 
  - Update tests to use tinyexec mock
  - Add comprehensive sudo coverage tests
  - Improve test organization and coverage

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Test Plan

- [x] Verify sudo detection works correctly on Linux
- [x] Verify non-root users get sudo prefix for npm commands
- [x] Verify root users do not get sudo prefix
- [x] Verify macOS/Windows users are unaffected
- [x] Verify Homebrew installations continue to use brew
- [x] All existing tests pass with updated mocks

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] i18n translations added for new messages
- [x] No new warnings introduced

---
Co-authored-by: LoopOuroboros <36392404+LoopOuroboros@users.noreply.github.com>


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Migrate from child_process to tinyexec for cross-platform command execution

- Add sudo support for Linux non-root users in npm global installs

- Implement shouldUseSudoForGlobalInstall() detection for Linux environments

- Apply sudo prefix to CCR, Claude Code, and CometixLine npm update commands

- Homebrew installations continue using brew without sudo

- Add i18n messages for sudo usage notification (English and Chinese)

- Refactor command execution to use tinyexec with argument arrays

- Expand test coverage with comprehensive sudo detection scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["child_process.execSync"] -->|"migrate to"| B["tinyexec exec"]
  C["Update Commands"] -->|"detect Linux non-root"| D["shouldUseSudoForGlobalInstall"]
  D -->|"true"| E["Add sudo prefix"]
  D -->|"false"| F["Direct execution"]
  E -->|"npm/claude commands"| G["Execute with sudo"]
  F -->|"npm/claude commands"| H["Execute without sudo"]
  I["Homebrew"] -->|"always skip sudo"| J["brew upgrade"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-updater.ts</strong><dd><code>Migrate to tinyexec and add sudo support for Linux</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/auto-updater.ts

<ul><li>Replaced child_process.execSync with tinyexec exec for command <br>execution<br> <li> Added shouldUseSudoForGlobalInstall() detection and conditional sudo <br>prefix for npm update commands<br> <li> Applied sudo support to updateCcr(), updateClaudeCode(), and <br>updateCometixLine() functions<br> <li> Maintained Homebrew installations without sudo (brew upgrade --cask)<br> <li> Added user notification via i18n when sudo is being used<br> <li> Refactored command execution to use exec with command and argument <br>array format</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/255/files#diff-3b39354b0048c81761cae5436b51e9fb12e249627624b5104ceff30af9c66d62">+30/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-updater.test.ts</strong><dd><code>Update tests for tinyexec and sudo support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/utils/auto-updater.test.ts

<ul><li>Updated mocks to use tinyexec instead of child_process and promisify<br> <li> Added shouldUseSudoForGlobalInstall mock for sudo detection testing<br> <li> Fixed test assertions to match new tinyexec command format with <br>argument arrays<br> <li> Added comprehensive sudo support test cases for all three tools (CCR, <br>Claude Code, CometixLine)<br> <li> Added test for Homebrew installations to verify sudo is not used<br> <li> Improved error handling test assertions to verify spinner.fail() is <br>called<br> <li> Added dedicated test suite for sudo support across all tools</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/255/files#diff-31666065b76773d02cf595aba9c2c946b8a841fa4affe32a981c3d6d025c4cf2">+253/-82</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>updater.json</strong><dd><code>Add English sudo usage notification message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/en/updater.json

<ul><li>Added new i18n key "usingSudo" with English message for sudo usage <br>notification<br> <li> Message informs users that sudo is being used for non-root Linux users <br>and password prompt may appear</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/255/files#diff-faae3498621b8319019301370cc7ab0096869b798dabeffbb5fed30e6f2582c3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>updater.json</strong><dd><code>Add Chinese sudo usage notification message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/zh-CN/updater.json

<ul><li>Added new i18n key "usingSudo" with Chinese translation for sudo usage <br>notification<br> <li> Message informs users in Chinese about sudo usage for non-root Linux <br>users</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/255/files#diff-a17a16f22e221512d4e17b1c13a252614ecc6919b480e90e89a97cfe0bec9c7e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

