### PR TITLE
docs: fix output style command across multiple languages

### DIFF
--- a/docs/en/advanced/templates.md
+++ b/docs/en/advanced/templates.md
@@ -104,7 +104,7 @@ npx zcf init -o skip
 
 **Claude Code**:
 ```
-/set-output-style engineer-professional
+/output-style engineer-professional
 ```
 
 **Codex**:

--- a/docs/en/best-practices/output-styles.md
+++ b/docs/en/best-practices/output-styles.md
@@ -46,7 +46,7 @@ npx zcf
 
 **Claude Code**:
 ```
-/set-output-style engineer-professional
+/output-style engineer-professional
 ```
 
 **Codex**:
@@ -124,13 +124,13 @@ Create different output styles for different scenarios:
 
 ```bash
 # During development: Use professional engineer style
-/set-output-style engineer-professional
+/output-style engineer-professional
 
 # During code review: Use review-specific style
-/set-output-style code-review
+/output-style code-review
 
 # During documentation: Use documentation style
-/set-output-style documentation
+/output-style documentation
 ```
 
 ### 3. Project-Specific Styles
@@ -142,7 +142,7 @@ For projects requiring independent styles, use project-level output styles:
 Project Root/.claude/output-style/project-specific.md
 
 # Use in conversation
-/set-output-style project-specific
+/output-style project-specific
 ```
 
 Project-specific styles override global styles but only take effect in that project.
@@ -238,7 +238,7 @@ npx zcf
 # Select 6, then select my-style
 
 # Or use in project
-/set-output-style my-style
+/output-style my-style
 ```
 
 ### Team Shared Styles
@@ -292,7 +292,7 @@ After creating new style, test its effects:
 
 ```bash
 # 1. Set new style
-/set-output-style my-new-style
+/output-style my-new-style
 
 # 2. Conduct test conversation
 Please help me implement a simple Todo feature

--- a/docs/en/best-practices/tips.md
+++ b/docs/en/best-practices/tips.md
@@ -290,7 +290,7 @@ npx zcf config-switch work --code-type codex
 npx zcf init -s -o all
 
 # Switch style in conversation
-# Claude Code: /set-output-style engineer-professional
+# Claude Code: /output-style engineer-professional
 # Codex: Configure through system prompt
 ```
 

--- a/docs/ja-JP/advanced/templates.md
+++ b/docs/ja-JP/advanced/templates.md
@@ -104,7 +104,7 @@ npx zcf init -o skip
 
 **Claude Code**:
 ```
-/set-output-style engineer-professional
+/output-style engineer-professional
 ```
 
 **Codex**:

--- a/docs/ja-JP/best-practices/output-styles.md
+++ b/docs/ja-JP/best-practices/output-styles.md
@@ -35,7 +35,7 @@ npx zcf init -o skip
 
 - **メインメニュー**：`npx zcf` → 6 を選択しスタイル管理へ。
 - **プロジェクト内**：  
-  - Claude Code: `/set-output-style engineer-professional`  
+  - Claude Code: `/output-style engineer-professional`  
   - Codex: `config.toml` の `systemPromptStyle` を編集。
 
 ### 編集
@@ -93,11 +93,11 @@ vim ~/.claude/prompts/output-style/my-custom-style.md
 
 ```bash
 # 実装フェーズ
-/set-output-style engineer-professional
+/output-style engineer-professional
 # レビュー時
-/set-output-style code-review
+/output-style code-review
 # ドキュメント作成時
-/set-output-style documentation
+/output-style documentation
 ```
 
 ### 3. プロジェクト専用スタイル
@@ -107,7 +107,7 @@ vim ~/.claude/prompts/output-style/my-custom-style.md
 Project/.claude/output-style/project-specific.md
 
 # 会話で指定
-/set-output-style project-specific
+/output-style project-specific
 ```
 
 優先度は「プロジェクト > グローバル > 内蔵」の順です。
@@ -130,7 +130,7 @@ cp team-output-styles/team-standards.md ~/.claude/prompts/output-style/
 
 1. ファイルを作成：`vim ~/.claude/prompts/output-style/my-style.md`
 2. 内容を書く（人格/コーディング規約/作業方法など）
-3. メニューまたは `/set-output-style my-style` で適用
+3. メニューまたは `/output-style my-style` で適用
 
 ## 注意点
 

--- a/docs/ja-JP/best-practices/tips.md
+++ b/docs/ja-JP/best-practices/tips.md
@@ -285,7 +285,7 @@ npx zcf config-switch glm-provider --code-type codex
 npx zcf init -s -o all
 
 # 会話中に切り替え
-# Claude Code: /set-output-style engineer-professional
+# Claude Code: /output-style engineer-professional
 # Codex: システムプロンプトで設定
 ```
 

--- a/docs/ja-JP/features/claude-code.md
+++ b/docs/ja-JP/features/claude-code.md
@@ -66,7 +66,7 @@ title: Claude Code 設定
 
 ## 出力スタイルと AI メモリ
 
-- `~/.claude/prompts/output-style/` に複数スタイルを同梱。`/set-output-style engineer-professional` などで切替。
+- `~/.claude/prompts/output-style/` に複数スタイルを同梱。`/output-style engineer-professional` などで切替。
 - AI メモリ（グローバル指示）は `~/.claude/CLAUDE.md` に保存。`npx zcf` → 6 で編集可能。
 
 ## MCP サービス

--- a/docs/zh-CN/advanced/templates.md
+++ b/docs/zh-CN/advanced/templates.md
@@ -104,7 +104,7 @@ npx zcf init -o skip
 
 **Claude Code**：
 ```
-/set-output-style engineer-professional
+/output-style engineer-professional
 ```
 
 **Codex**：

--- a/docs/zh-CN/best-practices/output-styles.md
+++ b/docs/zh-CN/best-practices/output-styles.md
@@ -46,7 +46,7 @@ npx zcf
 
 **Claude Code**：
 ```
-/set-output-style engineer-professional
+/output-style engineer-professional
 ```
 
 **Codex**：
@@ -124,13 +124,13 @@ ZCF 提供以下预置输出风格：
 
 ```bash
 # 开发时：使用专业工程师风格
-/set-output-style engineer-professional
+/output-style engineer-professional
 
 # 代码审查时：使用审查专用风格
-/set-output-style code-review
+/output-style code-review
 
 # 文档编写时：使用文档编写风格
-/set-output-style documentation
+/output-style documentation
 ```
 
 ### 3. 项目特定风格
@@ -142,7 +142,7 @@ ZCF 提供以下预置输出风格：
 项目根目录/.claude/output-style/project-specific.md
 
 # 在对话中使用
-/set-output-style project-specific
+/output-style project-specific
 ```
 
 项目特定风格会覆盖全局风格，但仅在该项目中生效。
@@ -238,7 +238,7 @@ npx zcf
 # 选择 6，然后选择 my-style
 
 # 或在项目中使用
-/set-output-style my-style
+/output-style my-style
 ```
 
 ### 团队共享风格
@@ -292,7 +292,7 @@ git commit -m "Update output style standards"
 
 ```bash
 # 1. 设置新风格
-/set-output-style my-new-style
+/output-style my-new-style
 
 # 2. 进行测试对话
 请帮我实现一个简单的 Todo 功能

--- a/docs/zh-CN/best-practices/tips.md
+++ b/docs/zh-CN/best-practices/tips.md
@@ -290,7 +290,7 @@ npx zcf config-switch work --code-type codex
 npx zcf init -s -o all
 
 # 在对话中切换风格
-# Claude Code: /set-output-style engineer-professional
+# Claude Code: /output-style engineer-professional
 # Codex: 通过系统提示配置
 ```
 


### PR DESCRIPTION
### **User description**
## Summary

- Replace `/set-output-style` with `/output-style` in documentation
- Ensure consistency in command usage for better user experience

## Changes

This PR fixes the output style command reference across multiple language documentation:

| Language | Files Updated |
|----------|---------------|
| English (en) | `templates.md`, `output-styles.md`, `tips.md` |
| Japanese (ja-JP) | `templates.md`, `output-styles.md`, `tips.md`, `claude-code.md` |
| Chinese (zh-CN) | `templates.md`, `output-styles.md`, `tips.md` |

### Details

- **Before**: `/set-output-style`
- **After**: `/output-style`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- [x] Verified correct command name in all affected documentation files
- [x] No code changes, documentation only
- [x] All references now consistently use `/output-style`

---
🤖 Generated with /zcf-pr command


___

### **PR Type**
Documentation


___

### **Description**
- Replace `/set-output-style` with `/output-style` command across documentation

- Update English, Japanese, and Chinese language documentation files

- Fix command references in templates, output-styles, tips, and claude-code docs

- Ensure consistent command usage for better user experience


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation Files<br/>en, ja-JP, zh-CN"] -- "Replace command" --> B["/set-output-style"]
  B -- "with" --> C["/output-style"]
  C --> D["Updated Docs<br/>templates, output-styles,<br/>tips, claude-code"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>templates.md</strong><dd><code>Replace output style command in English templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-b0db7d46103232d673f27f8a9d6e63a8a72d86028629d06567924d003d6df038">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output-styles.md</strong><dd><code>Fix command references in English output styles guide</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-8bb78af639fc3164f995500bf88882310fef0baed2f4a080f56a71ec55fe0b02">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tips.md</strong><dd><code>Update command in English tips documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-de1b7876a72f9fb2b16b97173633e14e05adda6ce5c8910b82e53f085fc34fc0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>templates.md</strong><dd><code>Replace output style command in Japanese templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-cf657d05e7648ff7f9cdec895d30911c17432cd2198c2152d631bc6f66b77cf8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output-styles.md</strong><dd><code>Fix command references in Japanese output styles guide</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-fab36df61377d8310e47852b4c6848264de0f751236853a7564a65d7dd59f36f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tips.md</strong><dd><code>Update command in Japanese tips documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-d365ab2d865d9eef4d686c59cb8beec9e411af32f6130ce6f264117f72f05580">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>claude-code.md</strong><dd><code>Fix command reference in Japanese Claude Code documentation</code></dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-81bd65d6e9a625f9a9889a86b90a712030ff56be8c0ebecdcaa0128a0d5784b5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>templates.md</strong><dd><code>Replace output style command in Chinese templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-875daced4ccfb1f8619cc118a87b52f85d365b547a6c54e1303e1de6ae1ad9d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output-styles.md</strong><dd><code>Fix command references in Chinese output styles guide</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-4360b2aaf809f930366c777383cc69d52bc8b0adc8e381c64360623bfac4e4d1">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tips.md</strong><dd><code>Update command in Chinese tips documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/272/files#diff-ebaa0ab3066faf2835bf1570c839a2b90d6b16cae14bd370e654e2b6b7cb7bc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies the output style command in documentation.
> 
> - Replaces `\`/set-output-style\`` with `\`/output-style\`` in English, Japanese, and Chinese docs
> - Updates examples and tips in `templates.md`, `best-practices/output-styles.md`, `best-practices/tips.md`, and JA `features/claude-code.md`
> - Ensures consistent command syntax across all showcased scenarios and code blocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d1cacf0bd183bc3b1fb87dfafa02d3e2cafac15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->