### PR TITLE
feat(mcp): add Claude Code Plugins marketplace services

### DIFF
--- a/src/config/mcp-services.ts
+++ b/src/config/mcp-services.ts
@@ -87,6 +87,37 @@ export const MCP_SERVICE_CONFIGS: McpServiceConfig[] = [
       env: {},
     },
   },
+  // Claude Code Plugins Marketplace - https://claudecodeplugins.io
+  {
+    id: 'project-health-auditor',
+    requiresApiKey: false,
+    config: {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@claude-code-plugins-plus/project-health-auditor@latest'],
+      env: {},
+    },
+  },
+  {
+    id: 'design-to-code',
+    requiresApiKey: false,
+    config: {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@claude-code-plugins-plus/design-to-code@latest'],
+      env: {},
+    },
+  },
+  {
+    id: 'conversational-api-debugger',
+    requiresApiKey: false,
+    config: {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@claude-code-plugins-plus/conversational-api-debugger@latest'],
+      env: {},
+    },
+  },
 ]
 
 /**
@@ -132,6 +163,22 @@ export async function getMcpServices(): Promise<McpService[]> {
       id: 'serena',
       name: i18n.t('mcp:services.serena.name'),
       description: i18n.t('mcp:services.serena.description'),
+    },
+    // Claude Code Plugins Marketplace
+    {
+      id: 'project-health-auditor',
+      name: i18n.t('mcp:services.project-health-auditor.name'),
+      description: i18n.t('mcp:services.project-health-auditor.description'),
+    },
+    {
+      id: 'design-to-code',
+      name: i18n.t('mcp:services.design-to-code.name'),
+      description: i18n.t('mcp:services.design-to-code.description'),
+    },
+    {
+      id: 'conversational-api-debugger',
+      name: i18n.t('mcp:services.conversational-api-debugger.name'),
+      description: i18n.t('mcp:services.conversational-api-debugger.description'),
     },
   ]
 

--- a/src/i18n/locales/en/mcp.json
+++ b/src/i18n/locales/en/mcp.json
@@ -18,6 +18,12 @@
   "services.spec-workflow.name": "Spec Workflow",
   "services.serena.name": "Serena Assistant",
   "services.serena.description": "Semantic code retrieval and editing akin to an IDE; extracts symbol-level entities and leverages relations to greatly improve token efficiency with coding agents",
+  "services.project-health-auditor.name": "Project Health Auditor",
+  "services.project-health-auditor.description": "Analyze code health, complexity, and test coverage gaps to identify technical debt hot spots",
+  "services.design-to-code.name": "Design to Code",
+  "services.design-to-code.description": "Convert Figma designs and screenshots to React, Vue, or Svelte components with accessibility",
+  "services.conversational-api-debugger.name": "API Debugger",
+  "services.conversational-api-debugger.description": "Debug REST API failures using OpenAPI specs and HTTP logs with root cause analysis",
   "apiKeyApprovalFailed": "Failed to manage API key approval status",
   "apiKeyPrompt": "Enter API Key",
   "primaryApiKeySetFailed": "Failed to set primaryApiKey"

--- a/src/i18n/locales/zh-CN/mcp.json
+++ b/src/i18n/locales/zh-CN/mcp.json
@@ -18,6 +18,12 @@
   "services.spec-workflow.name": "Spec 工作流",
   "services.serena.name": "Serena 助手",
   "services.serena.description": "提供类似 IDE 的语义代码检索与编辑，支持符号级实体提取与关系结构利用；与现有编码代理配合可显著提升标记效率",
+  "services.project-health-auditor.name": "项目健康审计",
+  "services.project-health-auditor.description": "分析代码健康度、复杂度和测试覆盖缺口，识别技术债务热点",
+  "services.design-to-code.name": "设计转代码",
+  "services.design-to-code.description": "将 Figma 设计和截图转换为 React、Vue 或 Svelte 组件，支持无障碍访问",
+  "services.conversational-api-debugger.name": "API 调试器",
+  "services.conversational-api-debugger.description": "使用 OpenAPI 规范和 HTTP 日志调试 REST API 故障，进行根因分析",
   "apiKeyApprovalFailed": "API密钥批准状态管理失败",
   "apiKeyPrompt": "请输入 API Key",
   "primaryApiKeySetFailed": "设置 primaryApiKey 失败"


### PR DESCRIPTION
### **User description**
## Summary

Adds 3 MCP services from [Claude Code Plugins Marketplace](https://claudecodeplugins.io/) to ZCF's preset list.

## New Services

| Service | Description |
|---------|-------------|
| **project-health-auditor** | Analyze code health, complexity, and test coverage gaps |
| **design-to-code** | Convert Figma designs/screenshots to React/Vue/Svelte |
| **conversational-api-debugger** | Debug REST APIs using OpenAPI specs and HTTP logs |

## Why Add These?

Claude Code Plugins is a marketplace with 258 plugins and 7 MCP servers. These 3 are our most popular:
- **No API keys required** - all work out of the box
- **Solve common developer pain points** - code quality, design handoff, API debugging
- **Actively maintained** - part of Issue #184 ZCF integration initiative

## Changes

- `src/config/mcp-services.ts` - Added 3 service configs
- `src/i18n/locales/en/mcp.json` - English translations
- `src/i18n/locales/zh-CN/mcp.json` - Chinese translations

## Testing

All services use `npx -y @claude-code-plugins-plus/[package]@latest` pattern matching existing ZCF services.

## Links

- Marketplace: https://claudecodeplugins.io/
- Repository: https://github.com/jeremylongshore/claude-code-plugins-plus-skills
- Requested by Tom Lucidor in Issue #184


___

### **PR Type**
Enhancement


___

### **Description**
- Adds 3 Claude Code Plugins marketplace MCP services
  - project-health-auditor: Code health and coverage analysis
  - design-to-code: Figma/screenshot to component conversion
  - conversational-api-debugger: REST API debugging with OpenAPI

- Includes English and Chinese translations for all services

- Services require no API keys and use npx execution pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Claude Code Plugins<br/>Marketplace"] -->|"3 new services"| B["MCP Service Configs"]
  B -->|"project-health-auditor"| C["Code Analysis"]
  B -->|"design-to-code"| D["Design Conversion"]
  B -->|"conversational-api-debugger"| E["API Debugging"]
  B -->|"i18n translations"| F["EN & ZH-CN"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-services.ts</strong><dd><code>Add 3 Claude Code Plugins MCP service configs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/mcp-services.ts

<ul><li>Added 3 new MCP service configurations from Claude Code Plugins <br>Marketplace<br> <li> Each service configured with npx command and latest package version<br> <li> Added service entries to getMcpServices() function with i18n <br>translations<br> <li> All services marked as requiresApiKey: false</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/279/files#diff-7b8dc338ca1abb9f1cb0e450b0a0821e219af85b825b8464a1ec34405f7be668">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp.json</strong><dd><code>Add English translations for new services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/en/mcp.json

<ul><li>Added English translations for project-health-auditor service<br> <li> Added English translations for design-to-code service<br> <li> Added English translations for conversational-api-debugger service<br> <li> Translations include service names and detailed descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/279/files#diff-61c33f78742869edca4efc75ae040dfb5dce01d020bdd1043c86480329210deb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp.json</strong><dd><code>Add Chinese translations for new services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/zh-CN/mcp.json

<ul><li>Added Chinese translations for project-health-auditor service<br> <li> Added Chinese translations for design-to-code service<br> <li> Added Chinese translations for conversational-api-debugger service<br> <li> Translations include service names and detailed descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/279/files#diff-461a251802957885c400a222c556033c066ca8359d5af82198454c366122113a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

