### PR TITLE
feat: add Leibus engineer output style (with test fix)

### DIFF
--- a/src/i18n/locales/en/configuration.json
+++ b/src/i18n/locales/en/configuration.json
@@ -56,6 +56,8 @@
   "outputStyles.nekomata-engineer.name": "Nekomata Engineer",
   "outputStyles.ojousama-engineer.description": "Tsundere blonde ojou-sama programmer Halley-chan, combining rigorous engineering excellence with tsundere ojou-sama traits",
   "outputStyles.ojousama-engineer.name": "Ojou-sama Engineer",
+  "outputStyles.leibus-engineer.description": "Marketing genius engineer background, providing technical services with ultimate product thinking and rigorous engineering quality",
+  "outputStyles.leibus-engineer.name": "LeiBus Engineer",
   "outputStyles.rem-engineer.description": "Loyal blue-haired maid programmer Rem, blending extreme gentle devotion with calm decisive execution",
   "outputStyles.rem-engineer.name": "Rem Maid Engineer",
   "permissionsImportSuccess": "Permissions imported",

--- a/src/i18n/locales/zh-CN/configuration.json
+++ b/src/i18n/locales/zh-CN/configuration.json
@@ -56,6 +56,8 @@
   "outputStyles.nekomata-engineer.name": "猫娘工程师",
   "outputStyles.ojousama-engineer.description": "傲娇金发大小姐程序员哈雷酱，融合严谨工程师素养与傲娇大小姐特质",
   "outputStyles.ojousama-engineer.name": "傲娇大小姐工程师",
+  "outputStyles.leibus-engineer.description": "工程师出身的营销鬼才，用极致的产品思维和严谨的工程素养为你提供技术服务",
+  "outputStyles.leibus-engineer.name": "雷布斯工程师",
   "outputStyles.rem-engineer.description": "忠诚的蓝发女仆程序员蕾姆，融合极度温柔的奉献精神与冷静果敢的执行力",
   "outputStyles.rem-engineer.name": "蕾姆女仆工程师",
   "permissionsImportSuccess": "权限配置已导入",

--- a/src/utils/output-style.ts
+++ b/src/utils/output-style.ts
@@ -41,6 +41,11 @@ const OUTPUT_STYLES: OutputStyle[] = [
     filePath: 'ojousama-engineer.md',
   },
   {
+    id: 'leibus-engineer',
+    isCustom: true,
+    filePath: 'leibus-engineer.md',
+  },
+  {
     id: 'rem-engineer',
     isCustom: true,
     filePath: 'rem-engineer.md',
@@ -158,6 +163,11 @@ export async function configureOutputStyle(
       id: 'ojousama-engineer',
       name: i18n.t('configuration:outputStyles.ojousama-engineer.name'),
       description: i18n.t('configuration:outputStyles.ojousama-engineer.description'),
+    },
+    {
+      id: 'leibus-engineer',
+      name: i18n.t('configuration:outputStyles.leibus-engineer.name'),
+      description: i18n.t('configuration:outputStyles.leibus-engineer.description'),
     },
     {
       id: 'rem-engineer',

--- a/tests/unit/utils/output-style.test.ts
+++ b/tests/unit/utils/output-style.test.ts
@@ -80,12 +80,13 @@ describe('output-style', () => {
     it('should return all available output styles', () => {
       const styles = getAvailableOutputStyles()
 
-      expect(styles).toHaveLength(8)
+      expect(styles).toHaveLength(9)
       expect(styles.map(s => s.id)).toEqual([
         'engineer-professional',
         'nekomata-engineer',
         'laowang-engineer',
         'ojousama-engineer',
+        'leibus-engineer',
         'rem-engineer',
         'default',
         'explanatory',
@@ -97,7 +98,7 @@ describe('output-style', () => {
       const styles = getAvailableOutputStyles()
       const customStyles = styles.filter(s => s.isCustom)
 
-      expect(customStyles).toHaveLength(5)
+      expect(customStyles).toHaveLength(6)
       customStyles.forEach((style) => {
         expect(style.filePath).toBeDefined()
         expect(style.filePath).toContain('.md')


### PR DESCRIPTION
### **User description**
## Summary
- Add leibus-engineer output style with presentation-style personality
- Add Chinese and English translations for the new style
- Create bilingual template files with comprehensive behavior guidelines
- **Fix test assertions**: Update custom styles count from 5 to 6, total styles from 8 to 9

This PR is based on #296 with the test assertion fix applied.

## Changes
- `src/utils/output-style.ts`: Add leibus-engineer style configuration
- `src/i18n/locales/en/configuration.json`: Add English translations
- `src/i18n/locales/zh-CN/configuration.json`: Add Chinese translations
- `tests/unit/utils/output-style.test.ts`: Fix test assertions (5→6 custom, 8→9 total)

Closes #296


___

### **PR Type**
Enhancement


___

### **Description**
- Add new 'leibus-engineer' output style with marketing-focused personality

- Include bilingual translations for English and Chinese locales

- Update test assertions to reflect new style count (8→9 total, 5→6 custom)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Output Style Configuration"] -->|Add leibus-engineer| B["src/utils/output-style.ts"]
  A -->|English translations| C["en/configuration.json"]
  A -->|Chinese translations| D["zh-CN/configuration.json"]
  B -->|Update counts| E["output-style.test.ts"]
  C --> F["Style Metadata"]
  D --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>output-style.ts</strong><dd><code>Register leibus-engineer output style configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/output-style.ts

<ul><li>Add new 'leibus-engineer' style entry to <code>OUTPUT_STYLES</code> array with <br>custom flag and template file path<br> <li> Register 'leibus-engineer' in <code>configureOutputStyle</code> function with i18n <br>translations<br> <li> Position new style between 'ojousama-engineer' and 'rem-engineer' in <br>the style list</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/298/files#diff-bd716a55311eeca1a03cb10f4638545219dc99e8e4c6a0557d4c1a7d18e35f0a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>output-style.test.ts</strong><dd><code>Update test assertions for new style count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/utils/output-style.test.ts

<ul><li>Update total available styles count from 8 to 9<br> <li> Update custom styles count from 5 to 6<br> <li> Add 'leibus-engineer' to expected style IDs array in test assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/298/files#diff-92a80c7cda2e6aa3bb42233f4c8fed250ce35660c03ba6098ae4e35e5dd61315">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.json</strong><dd><code>Add English translations for LeiBus Engineer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/en/configuration.json

<ul><li>Add English name: "LeiBus Engineer"<br> <li> Add English description highlighting marketing genius background with <br>product thinking and engineering quality<br> <li> Position translations between ojousama-engineer and rem-engineer <br>entries</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/298/files#diff-c9f8aff76222b63b0f096a91c127e3e6cfe91e4634e6bcc6044457b6f4199818">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.json</strong><dd><code>Add Chinese translations for LeiBus Engineer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/zh-CN/configuration.json

<ul><li>Add Chinese name: "雷布斯工程师" (LeiBus Engineer)<br> <li> Add Chinese description emphasizing marketing talent with product <br>thinking and engineering rigor<br> <li> Position translations between ojousama-engineer and rem-engineer <br>entries</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/298/files#diff-3eec2d50edf9e3bbd87becd7c2301355fe8395e774cb2a80263007518a855ef9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new custom output style and wires it through configuration and i18n, with tests updated to reflect the expanded set.
> 
> - Add `leibus-engineer` to `OUTPUT_STYLES` and to the interactive selection list in `output-style.ts`
> - Add English and Chinese i18n strings for `configuration.outputStyles.leibus-engineer.*`
> - Update unit tests: expect 9 total styles (6 custom, 3 built-in) and include `leibus-engineer` in IDs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34cbe290f308b32ce3a94ddaa89db706410b7f35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->