### PR TITLE
feat(codex): remove support for Codex chat format

### DIFF
--- a/.zcf/plan/history/2026-01-28_004229_remove-codex-chat-format.md
+++ b/.zcf/plan/history/2026-01-28_004229_remove-codex-chat-format.md
@@ -1,0 +1,45 @@
+# Remove Codex Chat Format Support
+
+## Task Description
+Codex 新版不再支持 chat 格式，需要删除相关选项和功能，默认 responses；对于 Codex 自定义 API 的预设中转配置里只有 chat 格式的需要删除
+
+## Approach
+方案 2：保留 wireApi 字段但隐藏 UI 选项，默认使用 responses
+
+## Implementation Steps
+
+### Step 1: Modify api-providers.ts
+- Change `wireApi: 'responses' | 'chat'` to `wireApi: 'responses'`
+- Remove codex config from GLM, MiniMax, Kimi presets (chat-only)
+
+### Step 2: Modify codex-provider-manager.ts
+- Change `wireApi?: 'responses' | 'chat'` to `wireApi?: 'responses'`
+- Simplify validation logic
+
+### Step 3: Modify codex.ts
+- Remove protocol selection UI
+- Default to 'responses'
+
+### Step 4: Modify codex-config-switch.ts
+- Remove protocol selection UI from add/edit/copy flows
+- Default to 'responses'
+
+### Step 5: Modify init.ts
+- Change wireApi type to only 'responses'
+
+### Step 6: Update i18n files
+- Remove protocolChat translation
+- Update wireApiInvalid message
+
+### Step 7: Run tests
+
+## Files to Modify
+1. src/config/api-providers.ts
+2. src/utils/code-tools/codex-provider-manager.ts
+3. src/utils/code-tools/codex.ts
+4. src/utils/code-tools/codex-config-switch.ts
+5. src/commands/init.ts
+6. src/i18n/locales/zh-CN/codex.json
+7. src/i18n/locales/en/codex.json
+
+## Status: In Progress

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1384,7 +1384,7 @@ async function convertToCodexProvider(config: ApiConfigDefinition): Promise<Code
 
   let baseUrl = config.url || API_DEFAULT_URL
   let model = config.primaryModel || 'gpt-5.2'
-  let wireApi: 'responses' | 'chat' = 'responses'
+  let wireApi = 'responses' as const
 
   if (config.provider && config.provider !== 'custom') {
     const { getProviderPreset } = await import('../config/api-providers')

--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -24,8 +24,8 @@ export interface ApiProviderPreset {
   codex?: {
     /** API base URL */
     baseUrl: string
-    /** Wire API protocol type */
-    wireApi: 'responses' | 'chat'
+    /** Wire API protocol type (only 'responses' is supported in new Codex) */
+    wireApi: 'responses'
     /** Default model (optional) */
     defaultModel?: string
   }
@@ -68,46 +68,31 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
   {
     id: 'glm',
     name: 'GLM',
-    supportedCodeTools: ['claude-code', 'codex'],
+    supportedCodeTools: ['claude-code'],
     claudeCode: {
       baseUrl: 'https://open.bigmodel.cn/api/anthropic',
       authType: 'auth_token',
-    },
-    codex: {
-      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
-      wireApi: 'chat',
-      defaultModel: 'GLM-4.7',
     },
     description: 'GLM (智谱AI)',
   },
   {
     id: 'minimax',
     name: 'MiniMax',
-    supportedCodeTools: ['claude-code', 'codex'],
+    supportedCodeTools: ['claude-code'],
     claudeCode: {
       baseUrl: 'https://api.minimaxi.com/anthropic',
       authType: 'auth_token',
       defaultModels: ['MiniMax-M2', 'MiniMax-M2'],
-    },
-    codex: {
-      baseUrl: 'https://api.minimaxi.com/v1',
-      wireApi: 'chat',
-      defaultModel: 'MiniMax-M2',
     },
     description: 'MiniMax API Service',
   },
   {
     id: 'kimi',
     name: 'Kimi',
-    supportedCodeTools: ['claude-code', 'codex'],
+    supportedCodeTools: ['claude-code'],
     claudeCode: {
       baseUrl: 'https://api.kimi.com/coding/',
       authType: 'auth_token',
-    },
-    codex: {
-      baseUrl: 'https://api.kimi.com/coding/v1',
-      wireApi: 'chat',
-      defaultModel: 'kimi-for-coding',
     },
     description: 'Kimi (Moonshot AI)',
   },

--- a/src/i18n/locales/en/codex.json
+++ b/src/i18n/locales/en/codex.json
@@ -20,7 +20,6 @@
   "providerBaseUrlRequired": "Base URL is required",
   "providerProtocolPrompt": "Select protocol to use",
   "protocolResponses": "Responses (Recommended, new-generation response API with state management)",
-  "protocolChat": "Chat (Traditional chat completion API, requires message history)",
   "providerApiKeyPrompt": "API key value",
   "providerApiKeyRequired": "API key is required",
   "addProviderPrompt": "Add another provider?",
@@ -118,7 +117,7 @@
   "providerManager.providerIdRequired": "Provider ID is required",
   "providerManager.providerNameRequired": "Provider name is required",
   "providerManager.baseUrlRequired": "Base URL is required",
-  "providerManager.wireApiInvalid": "Wire API must be either \"responses\" or \"chat\"",
+  "providerManager.wireApiInvalid": "Wire API must be \"responses\"",
   "providerManager.unknownError": "Unknown error",
   "envKeyMigrationComplete": "✔ env_key to temp_env_key migration completed"
 }

--- a/src/i18n/locales/zh-CN/codex.json
+++ b/src/i18n/locales/zh-CN/codex.json
@@ -20,7 +20,6 @@
   "providerBaseUrlRequired": "必须填写基础 URL",
   "providerProtocolPrompt": "选择使用的协议",
   "protocolResponses": "Responses（推荐，新一代响应 API，支持状态管理）",
-  "protocolChat": "Chat（传统聊天补全 API，需要消息历史记录）",
   "providerApiKeyPrompt": "API Key 内容",
   "providerApiKeyRequired": "必须填写 API Key",
   "addProviderPrompt": "是否继续添加其他提供商？",
@@ -118,7 +117,7 @@
   "providerManager.providerIdRequired": "提供商 ID 是必需的",
   "providerManager.providerNameRequired": "提供商名称是必需的",
   "providerManager.baseUrlRequired": "基础 URL 是必需的",
-  "providerManager.wireApiInvalid": "Wire API 必须是 \"responses\" 或 \"chat\"",
+  "providerManager.wireApiInvalid": "Wire API 必须是 \"responses\"",
   "providerManager.unknownError": "未知错误",
   "envKeyMigrationComplete": "✔ 已完成 env_key 到 temp_env_key 的迁移"
 }

--- a/src/utils/code-tools/codex-config-switch.ts
+++ b/src/utils/code-tools/codex-config-switch.ts
@@ -86,7 +86,7 @@ async function handleAddProvider(): Promise<void> {
   }])
 
   let prefilledBaseUrl: string | undefined
-  let prefilledWireApi: 'responses' | 'chat' | undefined
+  let prefilledWireApi: 'responses' | undefined
   let prefilledModel: string | undefined
 
   if (selectedProvider !== 'custom') {
@@ -102,7 +102,6 @@ async function handleAddProvider(): Promise<void> {
   const answers = await inquirer.prompt<{
     providerName: string
     baseUrl: string
-    wireApi: string
     apiKey: string
   }>([
     {
@@ -126,17 +125,6 @@ async function handleAddProvider(): Promise<void> {
       default: prefilledBaseUrl || 'https://api.openai.com/v1',
       when: () => selectedProvider === 'custom',
       validate: input => !!input.trim() || i18n.t('codex:providerBaseUrlRequired'),
-    },
-    {
-      type: 'list',
-      name: 'wireApi',
-      message: i18n.t('codex:providerProtocolPrompt'),
-      choices: [
-        { name: i18n.t('codex:protocolResponses'), value: 'responses' },
-        { name: i18n.t('codex:protocolChat'), value: 'chat' },
-      ],
-      default: prefilledWireApi || 'responses',
-      when: () => selectedProvider === 'custom',
     },
     {
       type: 'input',
@@ -173,7 +161,7 @@ async function handleAddProvider(): Promise<void> {
     id: providerId,
     name: answers.providerName.trim(),
     baseUrl: selectedProvider === 'custom' ? answers.baseUrl.trim() : prefilledBaseUrl!,
-    wireApi: (selectedProvider === 'custom' ? answers.wireApi : prefilledWireApi) as 'responses' | 'chat',
+    wireApi: prefilledWireApi || 'responses',
     tempEnvKey: `${providerId.toUpperCase().replace(/-/g, '_')}_API_KEY`,
     requiresOpenaiAuth: true,
     model: prefilledModel || 'gpt-5.2', // Use provider's default model or fallback
@@ -240,7 +228,6 @@ async function handleEditProvider(providers: any[]): Promise<void> {
   const answers = await inquirer.prompt<{
     providerName: string
     baseUrl: string
-    wireApi: string
     apiKey: string
   }>([
     {
@@ -265,16 +252,6 @@ async function handleEditProvider(providers: any[]): Promise<void> {
       validate: input => !!input.trim() || i18n.t('codex:providerBaseUrlRequired'),
     },
     {
-      type: 'list',
-      name: 'wireApi',
-      message: i18n.t('codex:providerProtocolPrompt'),
-      choices: [
-        { name: i18n.t('codex:protocolResponses'), value: 'responses' },
-        { name: i18n.t('codex:protocolChat'), value: 'chat' },
-      ],
-      default: provider.wireApi,
-    },
-    {
       type: 'input',
       name: 'apiKey',
       message: i18n.t('codex:providerApiKeyPrompt'),
@@ -297,7 +274,7 @@ async function handleEditProvider(providers: any[]): Promise<void> {
   const updates = {
     name: answers.providerName.trim(),
     baseUrl: answers.baseUrl.trim(),
-    wireApi: answers.wireApi as 'responses' | 'chat',
+    wireApi: 'responses' as const,
     apiKey: answers.apiKey.trim(),
     model: model.trim(),
   }
@@ -354,7 +331,6 @@ async function handleCopyProvider(providers: any[]): Promise<void> {
   const answers = await inquirer.prompt<{
     providerName: string
     baseUrl: string
-    wireApi: string
     apiKey: string
   }>([
     {
@@ -377,16 +353,6 @@ async function handleCopyProvider(providers: any[]): Promise<void> {
       message: i18n.t('codex:providerBaseUrlPrompt'),
       default: provider.baseUrl,
       validate: input => !!input.trim() || i18n.t('codex:providerBaseUrlRequired'),
-    },
-    {
-      type: 'list',
-      name: 'wireApi',
-      message: i18n.t('codex:providerProtocolPrompt'),
-      choices: [
-        { name: i18n.t('codex:protocolResponses'), value: 'responses' },
-        { name: i18n.t('codex:protocolChat'), value: 'chat' },
-      ],
-      default: provider.wireApi,
     },
     {
       type: 'input',
@@ -414,7 +380,7 @@ async function handleCopyProvider(providers: any[]): Promise<void> {
     id: providerId,
     name: answers.providerName.trim(),
     baseUrl: answers.baseUrl.trim(),
-    wireApi: answers.wireApi as 'responses' | 'chat',
+    wireApi: 'responses',
     tempEnvKey: `${providerId.toUpperCase().replace(/-/g, '_')}_API_KEY`,
     requiresOpenaiAuth: provider.requiresOpenaiAuth ?? true,
     model: model.trim(),

--- a/src/utils/code-tools/codex-provider-manager.ts
+++ b/src/utils/code-tools/codex-provider-manager.ts
@@ -16,7 +16,7 @@ export interface ProviderOperationResult {
 export interface ProviderUpdateData {
   name?: string
   baseUrl?: string
-  wireApi?: 'responses' | 'chat'
+  wireApi?: 'responses'
   apiKey?: string
   model?: string
 }
@@ -301,7 +301,7 @@ export function validateProviderData(provider: Partial<CodexProvider>): {
     errors.push(i18n.t('codex:providerManager.baseUrlRequired'))
   }
 
-  if (provider.wireApi && !['responses', 'chat'].includes(provider.wireApi)) {
+  if (provider.wireApi && provider.wireApi !== 'responses') {
     errors.push(i18n.t('codex:providerManager.wireApiInvalid'))
   }
 

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -1634,7 +1634,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
     }])
 
     let prefilledBaseUrl: string | undefined
-    let prefilledWireApi: 'responses' | 'chat' | undefined
+    let prefilledWireApi: 'responses' | undefined
     let prefilledModel: string | undefined
 
     if (selectedProvider !== 'custom') {
@@ -1647,7 +1647,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
       }
     }
 
-    const answers = await inquirer.prompt<{ providerName: string, baseUrl: string, wireApi: string, apiKey: string }>([
+    const answers = await inquirer.prompt<{ providerName: string, baseUrl: string, apiKey: string }>([
       {
         type: 'input',
         name: 'providerName',
@@ -1673,17 +1673,6 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
         default: prefilledBaseUrl || ((answers: any) => existingMap.get(answers.providerId)?.baseUrl || 'https://api.openai.com/v1'),
         when: () => selectedProvider === 'custom',
         validate: input => !!input || i18n.t('codex:providerBaseUrlRequired'),
-      },
-      {
-        type: 'list',
-        name: 'wireApi',
-        message: i18n.t('codex:providerProtocolPrompt'),
-        choices: [
-          { name: i18n.t('codex:protocolResponses'), value: 'responses' },
-          { name: i18n.t('codex:protocolChat'), value: 'chat' },
-        ],
-        default: prefilledWireApi || ((answers: any) => existingMap.get(sanitizeProviderName(answers.providerName))?.wireApi || 'responses'),
-        when: () => selectedProvider === 'custom', // Only ask if custom
       },
       {
         type: 'input',
@@ -1747,7 +1736,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
       id: providerId,
       name: answers.providerName,
       baseUrl: selectedProvider === 'custom' ? answers.baseUrl : prefilledBaseUrl!,
-      wireApi: selectedProvider === 'custom' ? (answers.wireApi || 'responses') : prefilledWireApi!,
+      wireApi: prefilledWireApi || 'responses',
       tempEnvKey,
       requiresOpenaiAuth: true,
       model: customModel || prefilledModel || 'gpt-5.2', // Use custom model, provider's default model, or fallback

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -158,7 +158,7 @@ describe('aPI Provider Configuration', () => {
         supportedCodeTools: ['codex'],
         codex: {
           baseUrl: 'https://minimal.com',
-          wireApi: 'chat',
+          wireApi: 'responses',
         },
       }
       expect(minimalProvider).toBeDefined()
@@ -177,7 +177,7 @@ describe('aPI Provider Configuration', () => {
         },
         codex: {
           baseUrl: 'https://dual.com/v1',
-          wireApi: 'chat',
+          wireApi: 'responses',
         },
       }
       expect(dualProvider).toBeDefined()

--- a/tests/unit/utils/code-tools/codex-incremental-config.test.ts
+++ b/tests/unit/utils/code-tools/codex-incremental-config.test.ts
@@ -102,7 +102,7 @@ describe('codex-incremental-config integration', () => {
       const editUpdates = {
         name: 'Updated Provider 1',
         baseUrl: 'https://api.updated-provider1.com/v1',
-        wireApi: 'chat' as const,
+        wireApi: 'responses' as const,
         apiKey: 'updated-api-key-1',
       }
 

--- a/tests/unit/utils/code-tools/codex-provider-manager.test.ts
+++ b/tests/unit/utils/code-tools/codex-provider-manager.test.ts
@@ -282,7 +282,7 @@ describe('codex-provider-manager', () => {
       const updates = {
         name: 'Updated Provider Name',
         baseUrl: 'https://api.updated.com/v1',
-        wireApi: 'chat' as const,
+        wireApi: 'responses' as const,
         apiKey: 'updated-api-key',
       }
 
@@ -709,13 +709,6 @@ describe('codex-provider-manager', () => {
     })
 
     it('should accept valid wireApi values', () => {
-      const chatProvider = {
-        id: 'test-provider',
-        name: 'Test Provider',
-        baseUrl: 'https://api.test.com/v1',
-        wireApi: 'chat',
-      }
-
       const responsesProvider = {
         id: 'test-provider',
         name: 'Test Provider',
@@ -723,8 +716,18 @@ describe('codex-provider-manager', () => {
         wireApi: 'responses',
       }
 
-      expect(validateProviderData(chatProvider).valid).toBe(true)
       expect(validateProviderData(responsesProvider).valid).toBe(true)
+    })
+
+    it('should reject invalid wireApi values', () => {
+      const chatProvider = {
+        id: 'test-provider',
+        name: 'Test Provider',
+        baseUrl: 'https://api.test.com/v1',
+        wireApi: 'chat', // chat is no longer supported
+      }
+
+      expect(validateProviderData(chatProvider).valid).toBe(false)
     })
 
     it('should handle partial provider data correctly', () => {


### PR DESCRIPTION
### **User description**
## Description

This PR removes the chat format support from Codex configuration, simplifying the codebase by defaulting to the 'responses' format only.

### Key Changes

- **Removed chat format option**: Eliminated chat format support from Codex, updating related configurations to default to 'responses'
- **Simplified API providers**: Modified `api-providers.ts` to remove chat-related configurations
- **Updated provider manager**: Cleaned up `codex-provider-manager.ts` to remove chat format handling
- **Streamlined config switch**: Simplified `codex-config-switch.ts` by removing chat format switching logic
- **Updated i18n**: Removed chat-related translations from both `en/codex.json` and `zh-CN/codex.json`
- **Test updates**: Ensured all relevant tests validate the new configuration

### Files Modified

- `src/config/api-providers.ts` - Removed chat format configurations
- `src/utils/code-tools/codex-provider-manager.ts` - Removed chat format handling
- `src/utils/code-tools/codex-config-switch.ts` - Simplified config switching
- `src/utils/code-tools/codex.ts` - Removed chat format support
- `src/commands/init.ts` - Minor adjustment
- `src/i18n/locales/en/codex.json` - Removed chat translations
- `src/i18n/locales/zh-CN/codex.json` - Removed chat translations
- `tests/unit/config/api-providers.test.ts` - Updated tests
- `tests/unit/utils/code-tools/codex-incremental-config.test.ts` - Updated tests
- `tests/unit/utils/code-tools/codex-provider-manager.test.ts` - Updated tests

## Type of Change

- [ ] Bug fix
- [x] New feature / Enhancement
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Code changes tested
- [x] No new warnings introduced
- [x] Code follows style guidelines
- [x] Tests added/updated

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Code follows project guidelines

## Additional Information

**Branch:** `feat/codex-remove-chat-wire-api` → `main`
**Commits:** 1
**Files Changed:** 11 (75 insertions, 89 deletions)

### Commit History

```
d3e7345 feat(codex): remove support for Codex chat format
```

---
🤖 Generated with /zcf-pr command


___

### **PR Type**
Enhancement


___

### **Description**
- Removed chat format support from Codex, defaulting to 'responses' only

- Eliminated wireApi UI prompts from provider configuration flows

- Removed chat-only provider presets (GLM, MiniMax, Kimi)

- Updated validation logic and i18n translations for wireApi field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Codex Configuration"] -->|Remove chat option| B["wireApi: responses only"]
  C["Provider Presets"] -->|Remove chat configs| D["GLM, MiniMax, Kimi"]
  E["UI Prompts"] -->|Remove protocol selection| F["Simplified flows"]
  B --> G["Updated Validation"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>api-providers.ts</strong><dd><code>Restrict wireApi to responses and remove chat presets</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-103b538fb4e1765c24636ac237fc677dff477bd13b58f70ec605d335b455e814">+5/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex-provider-manager.ts</strong><dd><code>Update wireApi type and validation for responses only</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-65c41ae73657b36418a54de9c3caa2eacf8fa598cc20595c40ce9c99ab0b006a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex-config-switch.ts</strong><dd><code>Remove protocol selection UI from provider flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-63de410b7812acdb54141d3306dcacc4928e42531b1b9e0154713fb1a9075950">+4/-38</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex.ts</strong><dd><code>Remove wireApi prompt from configuration flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-7a1a0fb7cc59b17a1624e0c85bbe94b13f12441fda1f4bfe417a4452c26aae02">+3/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>init.ts</strong><dd><code>Change wireApi type to responses constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-ec8485d3117f43c2d2d8e3ec7b2830f2d6b5df3f20626a62b04f61ccd70ec93f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>codex.json</strong><dd><code>Remove chat protocol translation and update validation message</code></dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-041abcb750f971c813a067f66ca5fe7a4b2458f9d56584c72b82f30179fb836e">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex.json</strong><dd><code>Remove chat protocol translation and update validation message</code></dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-12af58c134a6a4a1b4bc83fdfdd0e3adcd4edec68287f1ee8811e168842e85c3">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>2026-01-28_004229_remove-codex-chat-format.md</strong><dd><code>Add implementation plan documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-28b8eff3dcdddd362fe534d26237977c6dd6ee5b54a039a38107b7d890cb6e94">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>api-providers.test.ts</strong><dd><code>Update test cases to use responses wireApi</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-b889f249678bb63a0f603027db9312c26059c528d13eba9d70d5724c4d8c8b2d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex-incremental-config.test.ts</strong><dd><code>Update test wireApi value to responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-eebdbbaf76e442756b260cc67ef9e3df902ff33060646ddf8acf1a0d92fa9197">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex-provider-manager.test.ts</strong><dd><code>Update validation tests for responses-only wireApi</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/306/files#diff-c6fa31302e3545508468a467b140e00f4e96f229c1013fbdb0944267011eb437">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

