### PR TITLE
feat(api-providers): add AICodeMirror API provider presets

### DIFF
--- a/.zcf/plan/history/2026-01-30_191017_add-aicodemirror-preset.md
+++ b/.zcf/plan/history/2026-01-30_191017_add-aicodemirror-preset.md
@@ -1,0 +1,33 @@
+# Task: Add AICodeMirror API Preset
+
+## Context
+
+Add AICodeMirror API provider preset with two variants:
+- `aicodemirror`: Global High-Quality Line
+- `aicodemirror-cn`: China Optimized Line
+
+## Configuration Details
+
+| Variant | ClaudeCode URL | Codex URL |
+|---------|---------------|-----------|
+| Global | `https://api.aicodemirror.com/api/claudecode` | `https://api.aicodemirror.com/api/codex/backend-api/codex` |
+| CN | `https://api.claudecode.net.cn/api/claudecode` | `https://api.claudecode.net.cn/api/codex/backend-api/codex` |
+
+- Auth Type: `auth_token`
+- Codex Wire API: `responses`
+
+## Execution Steps
+
+- [x] Step 1: Modify `src/config/api-providers.ts` - Add two new presets after PackyCode
+- [ ] Step 2: Update `tests/unit/config/api-providers.test.ts` - Add test cases
+- [ ] Step 3: Update `docs/zh-CN/advanced/api-providers.md` - Chinese documentation
+- [ ] Step 4: Update `docs/en/advanced/api-providers.md` - English documentation
+- [ ] Step 5: Update `docs/ja-JP/advanced/api-providers.md` - Japanese documentation
+
+## Expected Results
+
+- Users can use `npx zcf init -s -p aicodemirror -k "token"` for global line
+- Users can use `npx zcf init -s -p aicodemirror-cn -k "token"` for CN line
+- Both Claude Code and Codex supported
+- Full test coverage
+- Trilingual documentation updated

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "language": "en,en-US",
   "allowCompoundWords": true,
   "words": [
+    "aicodemirror",
     "antfu",
     "Attributify",
     "bmad",

--- a/docs/en/advanced/api-providers.md
+++ b/docs/en/advanced/api-providers.md
@@ -13,6 +13,9 @@ ZCF currently supports the following API provider presets:
 | Preset ID | Provider Name | Description | Claude Code Support | Codex Support | Authentication Method |
 |---------|-----------|------|----------------|-----------|---------|
 | `302ai` | 302.AI | Enterprise-level AI API service | ✅ | ✅ | `api_key` |
+| `packycode` | PackyCode | PackyCode API service | ✅ | ✅ | `auth_token` |
+| `aicodemirror` | AICodeMirror | Global High-Quality Line | ✅ | ✅ | `auth_token` |
+| `aicodemirror-cn` | AICodeMirror CN | China Optimized Line | ✅ | ✅ | `auth_token` |
 | `glm` | GLM (Zhipu AI) | Zhipu AI service | ✅ | ✅ | `auth_token` |
 | `minimax` | MiniMax | MiniMax API service | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (Moonshot) | Moonshot AI service | ✅ | ✅ | `auth_token` |
@@ -43,6 +46,54 @@ npx zcf init -s -p 302ai -k "sk-xxx"
 
 # Codex
 npx zcf init -s -T codex -p 302ai -k "sk-xxx"
+```
+
+### AICodeMirror
+
+**Provider Name**: AICodeMirror
+
+**Features**:
+- 🌐 Global High-Quality Line
+- 🚀 High-speed stable connection
+- 🔧 Supports both Claude Code and Codex
+
+**Configuration Information**:
+- **Claude Code Base URL**: `https://api.aicodemirror.com/api/claudecode`
+- **Codex Base URL**: `https://api.aicodemirror.com/api/codex/backend-api/codex`
+- **Authentication Method**: `auth_token`
+- **Codex Wire API**: `responses`
+
+**Usage Example**:
+```bash
+# Claude Code
+npx zcf init -s -p aicodemirror -k "your-auth-token"
+
+# Codex
+npx zcf init -s -T codex -p aicodemirror -k "your-auth-token"
+```
+
+### AICodeMirror CN
+
+**Provider Name**: AICodeMirror CN (China Optimized Line)
+
+**Features**:
+- 🇨🇳 China Optimized Line
+- ⚡ Low-latency access
+- 🔧 Supports both Claude Code and Codex
+
+**Configuration Information**:
+- **Claude Code Base URL**: `https://api.claudecode.net.cn/api/claudecode`
+- **Codex Base URL**: `https://api.claudecode.net.cn/api/codex/backend-api/codex`
+- **Authentication Method**: `auth_token`
+- **Codex Wire API**: `responses`
+
+**Usage Example**:
+```bash
+# Claude Code
+npx zcf init -s -p aicodemirror-cn -k "your-auth-token"
+
+# Codex
+npx zcf init -s -T codex -p aicodemirror-cn -k "your-auth-token"
 ```
 
 ### GLM (Zhipu AI)

--- a/docs/ja-JP/advanced/api-providers.md
+++ b/docs/ja-JP/advanced/api-providers.md
@@ -13,6 +13,9 @@ ZCFは現在、以下のAPIプロバイダープリセットをサポートし�
 | プリセットID | プロバイダー名 | 説明 | Claude Code サポート | Codex サポート | 認証方式 |
 |---------|-----------|------|----------------|-----------|---------|
 | `302ai` | 302.AI | エンタープライズレベルのAI APIサービス | ✅ | ✅ | `api_key` |
+| `packycode` | PackyCode | PackyCode APIサービス | ✅ | ✅ | `auth_token` |
+| `aicodemirror` | AICodeMirror | グローバル高品質回線 | ✅ | ✅ | `auth_token` |
+| `aicodemirror-cn` | AICodeMirror CN | 中国最適化回線 | ✅ | ✅ | `auth_token` |
 | `glm` | GLM (智譜AI) | 智譜AIサービス | ✅ | ✅ | `auth_token` |
 | `minimax` | MiniMax | MiniMax APIサービス | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (月の暗面) | Moonshot AIサービス | ✅ | ✅ | `auth_token` |
@@ -43,6 +46,54 @@ npx zcf init -s -p 302ai -k "sk-xxx"
 
 # Codex
 npx zcf init -s -T codex -p 302ai -k "sk-xxx"
+```
+
+### AICodeMirror
+
+**プロバイダー名**: AICodeMirror
+
+**特徴**:
+- 🌐 グローバル高品質回線
+- 🚀 高速で安定した接続
+- 🔧 Claude CodeとCodexの両方をサポート
+
+**設定情報**:
+- **Claude Code Base URL**: `https://api.aicodemirror.com/api/claudecode`
+- **Codex Base URL**: `https://api.aicodemirror.com/api/codex/backend-api/codex`
+- **認証方式**: `auth_token`
+- **Codex Wire API**: `responses`
+
+**使用例**:
+```bash
+# Claude Code
+npx zcf init -s -p aicodemirror -k "your-auth-token"
+
+# Codex
+npx zcf init -s -T codex -p aicodemirror -k "your-auth-token"
+```
+
+### AICodeMirror CN
+
+**プロバイダー名**: AICodeMirror CN (中国最適化回線)
+
+**特徴**:
+- 🇨🇳 中国最適化回線
+- ⚡ 低遅延アクセス
+- 🔧 Claude CodeとCodexの両方をサポート
+
+**設定情報**:
+- **Claude Code Base URL**: `https://api.claudecode.net.cn/api/claudecode`
+- **Codex Base URL**: `https://api.claudecode.net.cn/api/codex/backend-api/codex`
+- **認証方式**: `auth_token`
+- **Codex Wire API**: `responses`
+
+**使用例**:
+```bash
+# Claude Code
+npx zcf init -s -p aicodemirror-cn -k "your-auth-token"
+
+# Codex
+npx zcf init -s -T codex -p aicodemirror-cn -k "your-auth-token"
 ```
 
 ### GLM (智譜AI)

--- a/docs/zh-CN/advanced/api-providers.md
+++ b/docs/zh-CN/advanced/api-providers.md
@@ -13,6 +13,9 @@ ZCF 目前支持以下 API 提供商预设：
 | 预设 ID | 提供商名称 | 描述 | Claude Code 支持 | Codex 支持 | 认证方式 |
 |---------|-----------|------|----------------|-----------|---------|
 | `302ai` | 302.AI | 企业级 AI API 服务 | ✅ | ✅ | `api_key` |
+| `packycode` | PackyCode | PackyCode API 服务 | ✅ | ✅ | `auth_token` |
+| `aicodemirror` | AICodeMirror | 全球高保线路 | ✅ | ✅ | `auth_token` |
+| `aicodemirror-cn` | AICodeMirror CN | 国内优化线路 | ✅ | ✅ | `auth_token` |
 | `glm` | GLM (智谱AI) | 智谱 AI 服务 | ✅ | ✅ | `auth_token` |
 | `minimax` | MiniMax | MiniMax API 服务 | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (月之暗面) | Moonshot AI 服务 | ✅ | ✅ | `auth_token` |
@@ -43,6 +46,54 @@ npx zcf init -s -p 302ai -k "sk-xxx"
 
 # Codex
 npx zcf init -s -T codex -p 302ai -k "sk-xxx"
+```
+
+### AICodeMirror
+
+**提供商名称**：AICodeMirror
+
+**特点**：
+- 🌐 全球高保线路
+- 🚀 高速稳定连接
+- 🔧 同时支持 Claude Code 和 Codex
+
+**配置信息**：
+- **Claude Code Base URL**: `https://api.aicodemirror.com/api/claudecode`
+- **Codex Base URL**: `https://api.aicodemirror.com/api/codex/backend-api/codex`
+- **认证方式**: `auth_token`
+- **Codex Wire API**: `responses`
+
+**使用示例**：
+```bash
+# Claude Code
+npx zcf init -s -p aicodemirror -k "your-auth-token"
+
+# Codex
+npx zcf init -s -T codex -p aicodemirror -k "your-auth-token"
+```
+
+### AICodeMirror CN
+
+**提供商名称**：AICodeMirror CN (国内优化线路)
+
+**特点**：
+- 🇨🇳 国内优化线路
+- ⚡ 低延迟访问
+- 🔧 同时支持 Claude Code 和 Codex
+
+**配置信息**：
+- **Claude Code Base URL**: `https://api.claudecode.net.cn/api/claudecode`
+- **Codex Base URL**: `https://api.claudecode.net.cn/api/codex/backend-api/codex`
+- **认证方式**: `auth_token`
+- **Codex Wire API**: `responses`
+
+**使用示例**：
+```bash
+# Claude Code
+npx zcf init -s -p aicodemirror-cn -k "your-auth-token"
+
+# Codex
+npx zcf init -s -T codex -p aicodemirror-cn -k "your-auth-token"
 ```
 
 ### GLM (智谱AI)

--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -66,6 +66,34 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
     description: 'PackyCode API Service',
   },
   {
+    id: 'aicodemirror',
+    name: 'AICodeMirror',
+    supportedCodeTools: ['claude-code', 'codex'],
+    claudeCode: {
+      baseUrl: 'https://api.aicodemirror.com/api/claudecode',
+      authType: 'auth_token',
+    },
+    codex: {
+      baseUrl: 'https://api.aicodemirror.com/api/codex/backend-api/codex',
+      wireApi: 'responses',
+    },
+    description: 'AICodeMirror Global High-Quality Line',
+  },
+  {
+    id: 'aicodemirror-cn',
+    name: 'AICodeMirror CN',
+    supportedCodeTools: ['claude-code', 'codex'],
+    claudeCode: {
+      baseUrl: 'https://api.claudecode.net.cn/api/claudecode',
+      authType: 'auth_token',
+    },
+    codex: {
+      baseUrl: 'https://api.claudecode.net.cn/api/codex/backend-api/codex',
+      wireApi: 'responses',
+    },
+    description: 'AICodeMirror China Optimized Line',
+  },
+  {
     id: 'glm',
     name: 'GLM',
     supportedCodeTools: ['claude-code'],

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -42,6 +42,30 @@ describe('aPI Provider Configuration', () => {
       expect(provider302!.supportedCodeTools).toContain('codex')
     })
 
+    it('aicodemirror provider should have correct configuration', () => {
+      const provider = API_PROVIDER_PRESETS.find(p => p.id === 'aicodemirror')
+      expect(provider).toBeDefined()
+      expect(provider!.name).toBe('AICodeMirror')
+      expect(provider!.supportedCodeTools).toContain('claude-code')
+      expect(provider!.supportedCodeTools).toContain('codex')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.aicodemirror.com/api/claudecode')
+      expect(provider!.claudeCode?.authType).toBe('auth_token')
+      expect(provider!.codex?.baseUrl).toBe('https://api.aicodemirror.com/api/codex/backend-api/codex')
+      expect(provider!.codex?.wireApi).toBe('responses')
+    })
+
+    it('aicodemirror-cn provider should have correct configuration', () => {
+      const provider = API_PROVIDER_PRESETS.find(p => p.id === 'aicodemirror-cn')
+      expect(provider).toBeDefined()
+      expect(provider!.name).toBe('AICodeMirror CN')
+      expect(provider!.supportedCodeTools).toContain('claude-code')
+      expect(provider!.supportedCodeTools).toContain('codex')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.claudecode.net.cn/api/claudecode')
+      expect(provider!.claudeCode?.authType).toBe('auth_token')
+      expect(provider!.codex?.baseUrl).toBe('https://api.claudecode.net.cn/api/codex/backend-api/codex')
+      expect(provider!.codex?.wireApi).toBe('responses')
+    })
+
     it('302.ai should have Claude Code configuration', () => {
       const provider302 = API_PROVIDER_PRESETS.find(p => p.id === '302ai')
       expect(provider302!.claudeCode).toBeDefined()


### PR DESCRIPTION
### **User description**
## Summary

Add two new API provider presets for AICodeMirror service.

## Changes

### New Provider Presets

| Preset ID | Name | Description |
|-----------|------|-------------|
| `aicodemirror` | AICodeMirror | Global High-Quality Line |
| `aicodemirror-cn` | AICodeMirror CN | China Optimized Line |

### Configuration Details

- **Authentication**: `auth_token`
- **Supported Tools**: Claude Code, Codex
- **Codex Wire API**: `responses`

### API Endpoints

| Variant | Claude Code URL | Codex URL |
|---------|-----------------|-----------|
| Global | `https://api.aicodemirror.com/api/claudecode` | `https://api.aicodemirror.com/api/codex/backend-api/codex` |
| CN | `https://api.claudecode.net.cn/api/claudecode` | `https://api.claudecode.net.cn/api/codex/backend-api/codex` |

## Usage

```bash
# Global Line - Claude Code
npx zcf init -s -p aicodemirror -k "your-auth-token"

# Global Line - Codex
npx zcf init -s -T codex -p aicodemirror -k "your-auth-token"

# China Optimized Line - Claude Code
npx zcf init -s -p aicodemirror-cn -k "your-auth-token"

# China Optimized Line - Codex
npx zcf init -s -T codex -p aicodemirror-cn -k "your-auth-token"
```

## Files Changed

- `src/config/api-providers.ts` - Add provider configurations
- `tests/unit/config/api-providers.test.ts` - Add test cases
- `docs/zh-CN/advanced/api-providers.md` - Update Chinese documentation
- `docs/en/advanced/api-providers.md` - Update English documentation
- `docs/ja-JP/advanced/api-providers.md` - Update Japanese documentation

## Testing

- [x] All existing tests pass
- [x] New test cases added for both providers
- [x] TypeScript type check passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add two AICodeMirror API provider presets (global and China-optimized)

- Support Claude Code and Codex tools with auth_token authentication

- Add comprehensive test coverage for both new providers

- Update trilingual documentation (English, Chinese, Japanese)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Provider Config"] -->|"Add aicodemirror preset"| B["Global High-Quality Line"]
  A -->|"Add aicodemirror-cn preset"| C["China Optimized Line"]
  B -->|"Support"| D["Claude Code + Codex"]
  C -->|"Support"| D
  E["Test Cases"] -->|"Verify"| B
  E -->|"Verify"| C
  F["Documentation"] -->|"Update"| G["EN, ZH-CN, JA-JP"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-providers.ts</strong><dd><code>Add two AICodeMirror provider presets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/api-providers.ts

<ul><li>Add <code>aicodemirror</code> preset with global API endpoints for Claude Code and <br>Codex<br> <li> Add <code>aicodemirror-cn</code> preset with China-optimized endpoints<br> <li> Both presets configured with <code>auth_token</code> authentication type<br> <li> Codex wire API set to <code>responses</code> for both variants</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-103b538fb4e1765c24636ac237fc677dff477bd13b58f70ec605d335b455e814">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-providers.test.ts</strong><dd><code>Add test cases for AICodeMirror providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/config/api-providers.test.ts

<ul><li>Add test case for <code>aicodemirror</code> provider configuration validation<br> <li> Add test case for <code>aicodemirror-cn</code> provider configuration validation<br> <li> Verify correct base URLs, authentication types, and supported tools<br> <li> Verify Codex wire API configuration for both providers</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-b889f249678bb63a0f603027db9312c26059c528d13eba9d70d5724c4d8c8b2d">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-providers.md</strong><dd><code>Document AICodeMirror providers in English</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/en/advanced/api-providers.md

<ul><li>Add <code>aicodemirror</code> and <code>aicodemirror-cn</code> entries to provider comparison <br>table<br> <li> Add detailed configuration sections for both AICodeMirror variants<br> <li> Include feature highlights, base URLs, and usage examples<br> <li> Document authentication method and Codex wire API configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-6c81a59b8643f8e4df9416897636251b105ae6bcff13868272074a3ec829c8b9">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api-providers.md</strong><dd><code>Document AICodeMirror providers in Chinese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/zh-CN/advanced/api-providers.md

<ul><li>Add <code>aicodemirror</code> and <code>aicodemirror-cn</code> entries to provider comparison <br>table<br> <li> Add detailed Chinese documentation for both AICodeMirror variants<br> <li> Include feature highlights (全球高保线路, 国内优化线路) and usage examples<br> <li> Document configuration details and authentication method</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-d32740b57378a61bb80d43438f6ea9a23ba6a214a6785d5ff80cc20b247c1485">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api-providers.md</strong><dd><code>Document AICodeMirror providers in Japanese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ja-JP/advanced/api-providers.md

<ul><li>Add <code>aicodemirror</code> and <code>aicodemirror-cn</code> entries to provider comparison <br>table<br> <li> Add detailed Japanese documentation for both AICodeMirror variants<br> <li> Include feature highlights (グローバル高品質回線, 中国最適化回線) and usage examples<br> <li> Document configuration details and authentication method</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-d4a579739e564814b182e29fc4e915d4ddd3fb9a3a4440d9e9bafe3ec85392d0">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>2026-01-30_191017_add-aicodemirror-preset.md</strong><dd><code>Add task planning document for AICodeMirror preset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.zcf/plan/history/2026-01-30_191017_add-aicodemirror-preset.md

<ul><li>Create task planning document for AICodeMirror preset implementation<br> <li> Document configuration details and execution steps<br> <li> Track completion status of implementation tasks<br> <li> Define expected results and usage patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-121cd2a77a3a4a11a19140ba8342c1e8659800aa90717128e5ee12be2c03c5a9">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cspell.json</strong><dd><code>Add AICodeMirror to spell checker dictionary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cspell.json

- Add `aicodemirror` to the spell checker word list


</details>


  </td>
  <td><a href="https://github.com/UfoMiao/zcf/pull/309/files#diff-77519f787fe7e051a14c588f101d61e4d8f0d3b01bf8e16cb65d3838243d4e68">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

