### PR TITLE
fix(codex-backup): skip tmp dir and handle dangling symlinks

### DIFF
--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -210,9 +210,11 @@ export function backupCodexFiles(): string | null {
   const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss')
   const backupDir = createBackupDirectory(timestamp)
 
+  const tmpDir = join(CODEX_DIR, 'tmp')
   const filter = (path: string): boolean => {
-    // Skip backup directories and temp directories (runtime artifacts, dangling symlinks)
-    return !path.includes('/backup') && !path.includes('/tmp')
+    // Skip backup directories and temp directory (runtime artifacts, dangling symlinks)
+    // Use precise path matching to avoid false positives like 'tmp-config.toml'
+    return !path.includes('/backup') && !path.startsWith(tmpDir)
   }
 
   copyDir(CODEX_DIR, backupDir, { filter })

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -211,7 +211,8 @@ export function backupCodexFiles(): string | null {
   const backupDir = createBackupDirectory(timestamp)
 
   const filter = (path: string): boolean => {
-    return !path.includes('/backup')
+    // Skip backup directories and temp directories (runtime artifacts, dangling symlinks)
+    return !path.includes('/backup') && !path.includes('/tmp')
   }
 
   copyDir(CODEX_DIR, backupDir, { filter })

--- a/tests/unit/utils/branch-coverage-boost.test.ts
+++ b/tests/unit/utils/branch-coverage-boost.test.ts
@@ -14,9 +14,10 @@ describe('branch coverage boost tests', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true)
     vi.mocked(fs.mkdirSync).mockImplementation(() => undefined)
     vi.mocked(fs.readdirSync).mockReturnValue(['file1.txt', 'file2.js'] as any)
-    vi.mocked(fs.statSync).mockReturnValue({
+    vi.mocked(fs.lstatSync).mockReturnValue({
       isDirectory: () => false,
       isFile: () => true,
+      isSymbolicLink: () => false,
     } as any)
     vi.mocked(fs.copyFileSync).mockImplementation(() => {})
 

--- a/tests/unit/utils/final-push.test.ts
+++ b/tests/unit/utils/final-push.test.ts
@@ -21,9 +21,10 @@ describe('final push for 90% branch coverage', () => {
     vi.mocked(fs.readdirSync)
       .mockReturnValueOnce(['subdir'] as any)
       .mockReturnValueOnce([] as any) // subdir is empty
-    vi.mocked(fs.statSync).mockReturnValue({
+    vi.mocked(fs.lstatSync).mockReturnValue({
       isDirectory: () => true,
       isFile: () => false,
+      isSymbolicLink: () => false,
     } as any)
     vi.mocked(fs.copyFileSync).mockImplementation(() => undefined)
 
@@ -42,11 +43,12 @@ describe('final push for 90% branch coverage', () => {
       .mockReturnValueOnce([] as any) // subdir is empty
 
     let statCallCount = 0
-    vi.mocked(fs.statSync).mockImplementation(() => {
+    vi.mocked(fs.lstatSync).mockImplementation(() => {
       statCallCount++
       return {
         isDirectory: () => statCallCount === 2, // second call is for subdir
         isFile: () => statCallCount === 1, // first call is for file
+        isSymbolicLink: () => false,
       } as any
     })
 


### PR DESCRIPTION
## Description

This PR fixes issue #319 where configuring Codex MCP fails with ENOENT error when backing up `~/.codex/tmp/` directory containing dangling symlinks.

### Root Cause

1. `backupCodexFiles()` recursively copies `~/.codex/` but filter only excluded `/backup`, not `/tmp`
2. `copyDir()` used `statSync` which follows symlinks - dangling symlinks throw ENOENT
3. Race condition: files could be deleted between `readdir()` and `stat()` calls

### Changes

| File | Change |
|------|--------|
| `src/utils/fs-operations.ts` | Use `lstatSync` instead of `statSync`, skip symlinks, handle ENOENT gracefully |
| `src/utils/code-tools/codex.ts` | Filter excludes `/tmp` directory from backup |
| Tests | Update mocks to use `lstatSync` with `isSymbolicLink` method |

### Testing

- ✅ All 2485 tests pass
- ✅ Lint clean
- ✅ TypeCheck pass

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Closes #319

---
🤖 Generated with /zcf-pr command