### PR TITLE
fix: update MiniMax provider preset to M2.7 models and correct API endpoint

### DIFF
--- a/docs/en/advanced/api-providers.md
+++ b/docs/en/advanced/api-providers.md
@@ -153,18 +153,17 @@ npx zcf init -s -T codex -p glm -k "your-auth-token"
 
 **Provider Name**: MiniMax
 
+**Official Link**: [MiniMax Platform](https://platform.minimax.io)
+
 **Features**:
-- 🎯 Focuses on AI model services
-- 💡 Supports multiple application scenarios
-- 🔧 Flexible configuration options
+- 🎯 Peak performance AI models (MiniMax-M2.7)
+- 💡 204,800 tokens context window with up to 192K output
+- 🔧 Anthropic-compatible API for Claude Code
 
 **Configuration Information**:
-- **Claude Code Base URL**: `https://api.minimaxi.com/anthropic`
-- **Codex Base URL**: `https://api.minimaxi.com/v1`
+- **Claude Code Base URL**: `https://api.minimax.io/anthropic`
 - **Authentication Method**: `auth_token`
-- **Codex Wire API**: `chat`
-- **Claude Code Default Model**: `MiniMax-M2`
-- **Codex Default Model**: `MiniMax-M2`
+- **Claude Code Default Model**: `MiniMax-M2.7` (primary), `MiniMax-M2.7-highspeed` (fast)
 
 **Usage Example**:
 ```bash

--- a/docs/ja-JP/advanced/api-providers.md
+++ b/docs/ja-JP/advanced/api-providers.md
@@ -153,18 +153,17 @@ npx zcf init -s -T codex -p glm -k "your-auth-token"
 
 **プロバイダー名**: MiniMax
 
+**公式リンク**: [MiniMax プラットフォーム](https://platform.minimax.io)
+
 **特徴**:
-- 🎯 AIモデルサービスに焦点
-- 💡 複数のアプリケーションシナリオをサポート
-- 🔧 柔軟な設定オプション
+- 🎯 高性能AIモデル (MiniMax-M2.7)
+- 💡 204,800トークンのコンテキストウィンドウ、最大192K出力
+- 🔧 Anthropic互換API、Claude Code対応
 
 **設定情報**:
-- **Claude Code Base URL**: `https://api.minimaxi.com/anthropic`
-- **Codex Base URL**: `https://api.minimaxi.com/v1`
+- **Claude Code Base URL**: `https://api.minimax.io/anthropic`
 - **認証方式**: `auth_token`
-- **Codex Wire API**: `chat`
-- **Claude Code デフォルトモデル**: `MiniMax-M2`
-- **Codex デフォルトモデル**: `MiniMax-M2`
+- **Claude Code デフォルトモデル**: `MiniMax-M2.7`（メイン）、`MiniMax-M2.7-highspeed`（高速）
 
 **使用例**:
 ```bash

--- a/docs/zh-CN/advanced/api-providers.md
+++ b/docs/zh-CN/advanced/api-providers.md
@@ -153,18 +153,17 @@ npx zcf init -s -T codex -p glm -k "your-auth-token"
 
 **提供商名称**：MiniMax
 
+**官方链接**：[MiniMax 平台](https://platform.minimax.io)
+
 **特点**：
-- 🎯 专注于 AI 模型服务
-- 💡 支持多种应用场景
-- 🔧 灵活的配置选项
+- 🎯 高性能 AI 模型 (MiniMax-M2.7)
+- 💡 204,800 tokens 上下文窗口，最大 192K 输出
+- 🔧 兼容 Anthropic API，适配 Claude Code
 
 **配置信息**：
-- **Claude Code Base URL**: `https://api.minimaxi.com/anthropic`
-- **Codex Base URL**: `https://api.minimaxi.com/v1`
+- **Claude Code Base URL**: `https://api.minimax.io/anthropic`
 - **认证方式**: `auth_token`
-- **Codex Wire API**: `chat`
-- **Claude Code 默认模型**: `MiniMax-M2`
-- **Codex 默认模型**: `MiniMax-M2`
+- **Claude Code 默认模型**: `MiniMax-M2.7`（主力）、`MiniMax-M2.7-highspeed`（高速）
 
 **使用示例**：
 ```bash

--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -143,9 +143,9 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
     name: 'MiniMax',
     supportedCodeTools: ['claude-code'],
     claudeCode: {
-      baseUrl: 'https://api.minimaxi.com/anthropic',
+      baseUrl: 'https://api.minimax.io/anthropic',
       authType: 'auth_token',
-      defaultModels: ['MiniMax-M2', 'MiniMax-M2'],
+      defaultModels: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
     },
     description: 'MiniMax API Service',
   },

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -80,6 +80,16 @@ describe('aPI Provider Configuration', () => {
       expect(provider302!.codex!.wireApi).toBe('responses')
     })
 
+    it('minimax provider should have correct configuration', () => {
+      const provider = API_PROVIDER_PRESETS.find(p => p.id === 'minimax')
+      expect(provider).toBeDefined()
+      expect(provider!.name).toBe('MiniMax')
+      expect(provider!.supportedCodeTools).toContain('claude-code')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.minimax.io/anthropic')
+      expect(provider!.claudeCode?.authType).toBe('auth_token')
+      expect(provider!.claudeCode?.defaultModels).toEqual(['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'])
+    })
+
     it('providers with claudeCode config should have valid authType', () => {
       API_PROVIDER_PRESETS.forEach((provider) => {
         if (provider.claudeCode) {


### PR DESCRIPTION
## Summary

Update the MiniMax API provider preset with current endpoint and model information:

- **Fix API endpoint**: Update base URL from `api.minimaxi.com/anthropic` (deprecated) to `api.minimax.io/anthropic` (current overseas endpoint)
- **Update models**: Replace legacy `MiniMax-M2` with current `MiniMax-M2.7` (peak performance) and `MiniMax-M2.7-highspeed` (same performance, faster)
- **Fix duplicate entry**: The previous `defaultModels` array had `['MiniMax-M2', 'MiniMax-M2']` (duplicate) — now correctly lists two distinct models
- **Update docs**: Updated MiniMax provider documentation in all three languages (en/zh-CN/ja-JP) with correct endpoint, model names, and official platform link
- **Add test**: Added MiniMax-specific unit test to verify provider configuration

### Model Details

| Model | Context Window | Description |
|-------|---------------|-------------|
| MiniMax-M2.7 | 204,800 tokens | Peak Performance. Ultimate Value. Master the Complex |
| MiniMax-M2.7-highspeed | 204,800 tokens | Same performance, faster and more agile |

## Test Plan

- [x] `pnpm vitest run tests/unit/config/api-providers.test.ts` — all 25 tests pass
- [x] Lint and typecheck pass (verified by pre-commit hooks)
- [x] No breaking changes — only data updates to existing preset

## Files Changed

| File | Change |
|------|--------|
| `src/config/api-providers.ts` | Update baseUrl and defaultModels |
| `tests/unit/config/api-providers.test.ts` | Add MiniMax-specific test |
| `docs/en/advanced/api-providers.md` | Update MiniMax section |
| `docs/zh-CN/advanced/api-providers.md` | Update MiniMax section |
| `docs/ja-JP/advanced/api-providers.md` | Update MiniMax section |