### PR TITLE
feat(api-providers): add DeepSeek v4 provider preset

### DIFF
--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -166,7 +166,7 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
     claudeCode: {
       baseUrl: 'https://api.deepseek.com/anthropic',
       authType: 'auth_token',
-      defaultModels: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+      defaultModels: ['deepseek-v4-pro', 'deepseek-v4-flash'],
     },
     description: 'DeepSeek official API (Anthropic-compatible endpoint)',
   },

--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -160,6 +160,17 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
     description: 'Kimi (Moonshot AI)',
   },
   {
+    id: 'deepseek',
+    name: 'DeepSeek',
+    supportedCodeTools: ['claude-code'],
+    claudeCode: {
+      baseUrl: 'https://api.deepseek.com/anthropic',
+      authType: 'auth_token',
+      defaultModels: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+    },
+    description: 'DeepSeek official API (Anthropic-compatible endpoint)',
+  },
+  {
     id: 'pateway',
     name: 'PatewayAI',
     supportedCodeTools: ['claude-code', 'codex'],

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -103,7 +103,8 @@ describe('aPI Provider Configuration', () => {
       expect(provider!.supportedCodeTools).toContain('claude-code')
       expect(provider!.claudeCode?.baseUrl).toBe('https://api.deepseek.com/anthropic')
       expect(provider!.claudeCode?.authType).toBe('auth_token')
-      expect(provider!.claudeCode?.defaultModels).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro'])
+      // Order matters: [primary, haiku, sonnet, opus] — pro is the primary, flash maps to haiku
+      expect(provider!.claudeCode?.defaultModels).toEqual(['deepseek-v4-pro', 'deepseek-v4-flash'])
     })
 
     it('providers with claudeCode config should have valid authType', () => {

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -96,6 +96,16 @@ describe('aPI Provider Configuration', () => {
       expect(provider!.claudeCode?.defaultModels).toEqual(['glm-5'])
     })
 
+    it('deepseek provider should have correct configuration', () => {
+      const provider = API_PROVIDER_PRESETS.find(p => p.id === 'deepseek')
+      expect(provider).toBeDefined()
+      expect(provider!.name).toBe('DeepSeek')
+      expect(provider!.supportedCodeTools).toContain('claude-code')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.deepseek.com/anthropic')
+      expect(provider!.claudeCode?.authType).toBe('auth_token')
+      expect(provider!.claudeCode?.defaultModels).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro'])
+    })
+
     it('providers with claudeCode config should have valid authType', () => {
       API_PROVIDER_PRESETS.forEach((provider) => {
         if (provider.claudeCode) {


### PR DESCRIPTION
## Summary

- Add **DeepSeek** as a new Claude Code API provider preset using the official Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) with `auth_token` authentication.
- Pre-fill `defaultModels` with the new v4 family: `deepseek-v4-flash` and `deepseek-v4-pro`.
- Add a unit test in `tests/unit/config/api-providers.test.ts` covering the new preset's id, name, baseUrl, authType, and default models.

Closes #348

## Type of Change

- [x] New feature (non-breaking change)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Notes

Codex support is intentionally **not** included for DeepSeek in this PR. DeepSeek's OpenAI-compatible endpoint (`https://api.deepseek.com`) uses the `chat/completions` protocol, while the current `ApiProviderPreset.codex.wireApi` type only allows `'responses'` (per the comment in [src/config/api-providers.ts](src/config/api-providers.ts) — *"only 'responses' is supported in new Codex"*). Adding Codex support would require widening that type to accept `'chat'`, which is out of scope here. Happy to do that as a follow-up if desired.

## Test plan

- [x] `pnpm test:run tests/unit/config/api-providers.test.ts` — 27/27 pass
- [x] `pnpm test:run tests/unit/commands/init-api-provider.test.ts` — 25/25 pass (verifies preset wiring still works end-to-end)
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` (via husky pre-commit) — pass