### PR TITLE
fix(cometix): use cross-platform ccline status command

### DIFF
--- a/docs/en/features/cometix.md
+++ b/docs/en/features/cometix.md
@@ -289,7 +289,7 @@ npm install -g @cometix/ccline --registry https://registry.npmmirror.com
 
 Add to your Claude Code `settings.json`:
 
-**Linux/macOS:**
+**Cross-platform (recommended):**
 
 ```json
 {
@@ -301,17 +301,7 @@ Add to your Claude Code `settings.json`:
 }
 ```
 
-**Windows:**
-
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "%USERPROFILE%\\.claude\\ccline\\ccline.exe",
-    "padding": 0
-  }
-}
-```
+> Windows users should not use `%USERPROFILE%` paths. Claude Code v2.1.47+ supports `~` expansion, so use the cross-platform configuration above.
 
 **Fallback (npm installation):**
 

--- a/docs/ja-JP/features/cometix.md
+++ b/docs/ja-JP/features/cometix.md
@@ -54,7 +54,7 @@ npm install -g @cometix/ccline --registry https://registry.npmmirror.com
 
 Claude Code の `settings.json` に追加：
 
-**Linux/macOS：**
+**クロスプラットフォーム（推奨）：**
 
 ```json
 {
@@ -66,17 +66,7 @@ Claude Code の `settings.json` に追加：
 }
 ```
 
-**Windows：**
-
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "%USERPROFILE%\\.claude\\ccline\\ccline.exe",
-    "padding": 0
-  }
-}
-```
+> Windows ユーザーは `%USERPROFILE%` パスを使用しないでください。Claude Code v2.1.47+ は `~` の展開に対応しているため、上記のクロスプラットフォーム設定を使用してください。
 
 **フォールバック（npm インストール）：**
 

--- a/docs/zh-CN/features/cometix.md
+++ b/docs/zh-CN/features/cometix.md
@@ -289,7 +289,7 @@ npm install -g @cometix/ccline --registry https://registry.npmmirror.com
 
 添加到 Claude Code 的 `settings.json`：
 
-**Linux/macOS：**
+**跨平台通用（推荐）：**
 
 ```json
 {
@@ -301,17 +301,7 @@ npm install -g @cometix/ccline --registry https://registry.npmmirror.com
 }
 ```
 
-**Windows：**
-
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "%USERPROFILE%\\.claude\\ccline\\ccline.exe",
-    "padding": 0
-  }
-}
-```
+> Windows 用户请勿使用 `%USERPROFILE%` 路径。Claude Code v2.1.47+ 支持 `~` 展开，推荐使用上面的跨平台配置。
 
 **回退方案（npm 安装）：**
 

--- a/src/utils/statusline-validator.ts
+++ b/src/utils/statusline-validator.ts
@@ -1,5 +1,4 @@
 import type { StatusLineConfig } from '../types/config'
-import { isWindows } from './platform'
 
 /**
  * Validates StatusLine configuration structure
@@ -54,9 +53,7 @@ export function sanitizeStatusLineConfig(config: any): StatusLineConfig | null {
 export function getPlatformStatusLineConfig(): StatusLineConfig {
   return {
     type: 'command',
-    command: isWindows()
-      ? '%USERPROFILE%\\.claude\\ccline\\ccline.exe'
-      : '~/.claude/ccline/ccline',
+    command: '~/.claude/ccline/ccline',
     padding: 0,
   }
 }

--- a/tests/helpers/statusline-helpers.ts
+++ b/tests/helpers/statusline-helpers.ts
@@ -43,7 +43,7 @@ export const MOCK_STATUS_LINE_CONFIGS = {
   },
   windows: {
     type: 'command' as const,
-    command: '%USERPROFILE%\\.claude\\ccline\\ccline.exe',
+    command: '~/.claude/ccline/ccline',
     padding: 0,
   },
   custom: {

--- a/tests/integration/statusline-config.test.ts
+++ b/tests/integration/statusline-config.test.ts
@@ -133,12 +133,12 @@ describe('statusLine Configuration Integration', () => {
     expect(result?.permissions?.allow).toEqual(['Bash', 'Read', 'Write'])
   })
 
-  it('should handle Windows path format correctly', async () => {
-    // Arrange: Template with Windows statusLine path
+  it('should handle cross-platform statusLine path correctly', async () => {
+    // Arrange: Template with cross-platform statusLine path
     const templateSettings: ClaudeSettings = {
       statusLine: {
         type: 'command',
-        command: '%USERPROFILE%\\.claude\\ccline\\ccline.exe',
+        command: '~/.claude/ccline/ccline',
         padding: 0,
       },
     }
@@ -148,9 +148,9 @@ describe('statusLine Configuration Integration', () => {
     // Act: Merge settings
     mergeSettingsFile(templatePath, targetPath)
 
-    // Assert: Windows path should be preserved correctly
+    // Assert: Cross-platform path should be preserved correctly
     const result = readJsonConfig<ClaudeSettings>(targetPath)
 
-    expect(result?.statusLine?.command).toBe('%USERPROFILE%\\.claude\\ccline\\ccline.exe')
+    expect(result?.statusLine?.command).toBe('~/.claude/ccline/ccline')
   })
 })

--- a/tests/unit/config/statusline.test.ts
+++ b/tests/unit/config/statusline.test.ts
@@ -123,19 +123,18 @@ describe('statusLine Configuration', () => {
       )
     })
 
-    it('should handle platform-specific statusLine paths', () => {
-      // Red: This test should FAIL initially
-      const windowsTemplateSettings: ClaudeSettings = {
+    it('should handle cross-platform statusLine paths', () => {
+      const crossPlatformTemplateSettings: ClaudeSettings = {
         ...mockTemplateSettings,
         statusLine: {
           type: 'command',
-          command: '%USERPROFILE%\\.claude\\ccline\\ccline.exe',
+          command: '~/.claude/ccline/ccline',
           padding: 0,
         },
       }
 
       mockExists.mockReturnValue(false)
-      mockReadJsonConfig.mockReturnValue(windowsTemplateSettings)
+      mockReadJsonConfig.mockReturnValue(crossPlatformTemplateSettings)
 
       mergeSettingsFile('/template/settings.json', '/target/settings.json')
 
@@ -144,7 +143,7 @@ describe('statusLine Configuration', () => {
         expect.objectContaining({
           statusLine: {
             type: 'command',
-            command: '%USERPROFILE%\\.claude\\ccline\\ccline.exe',
+            command: '~/.claude/ccline/ccline',
             padding: 0,
           },
         }),

--- a/tests/unit/utils/statusline-validator.test.ts
+++ b/tests/unit/utils/statusline-validator.test.ts
@@ -108,7 +108,7 @@ describe('statusLine Validator', () => {
   })
 
   describe('getPlatformStatusLineConfig', () => {
-    it('should return Windows configuration on Windows platform', () => {
+    it('should return cross-platform configuration on Windows platform', () => {
       // Mock Windows platform
       mockIsWindows.mockReturnValue(true)
 
@@ -116,7 +116,7 @@ describe('statusLine Validator', () => {
 
       expect(result).toEqual({
         type: 'command',
-        command: '%USERPROFILE%\\.claude\\ccline\\ccline.exe',
+        command: '~/.claude/ccline/ccline',
         padding: 0,
       })
     })


### PR DESCRIPTION
## Description

This PR retargets the CCometixLine Claude Code statusLine fix to `main` for GitHub Issue #365.

### Key Changes:

- Generate `~/.claude/ccline/ccline` for all platforms instead of the unreliable Windows `%USERPROFILE%` command.
- Sync CCometixLine configuration examples in zh-CN, en, and ja-JP docs.
- Update unit/integration coverage and shared fixtures to assert the cross-platform command.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `pnpm vitest tests/unit/utils/statusline-validator.test.ts tests/unit/utils/ccometixline-config.test.ts tests/unit/config/statusline.test.ts tests/integration/statusline-config.test.ts --run`
- [x] `pnpm typecheck`

## Additional Information

**Branch:** `fix/ccometixline-statusline-main` -> `main`
**Commits:** 1

### Commit History:

```text
9931e3c fix(cometix): use cross-platform ccline status command
```

Note: the earlier PR #369 targeted `release/v3.6.6`; this PR is the replacement targeting `main`.

---
Generated with /zcf-pr command flow

Made with [Cursor](https://cursor.com)