### PR TITLE
UFO-10: 🚀 Release v3.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.6.7
+
+### Patch Changes
+
+- ## New Features
+  - Upgrade the MiniMax provider preset to use the M3 default model.
+
+  ## 新功能
+  - 将 MiniMax 提供商预设升级为默认使用 M3 模型。
+
+  ## Fixes
+  - Use a cross-platform CCometixLine status command so generated Claude Code status line configuration works consistently across macOS, Linux, Windows, and Termux.
+  - Update DeepWiki MCP configuration typing, tests, and multilingual documentation.
+
+  ## 修复
+  - 使用跨平台的 CCometixLine 状态栏命令，确保生成的 Claude Code 状态栏配置在 macOS、Linux、Windows 和 Termux 中保持一致。
+  - 更新 DeepWiki MCP 配置类型、测试与多语言文档。
+
 ## 3.6.6
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zcf",
   "type": "module",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "packageManager": "pnpm@10.17.1",
   "description": "Zero-Config Code Flow - One-click configuration tool for Code Cli",
   "author": {


### PR DESCRIPTION
## Description

Release version v3.6.7 with automated version bump and CHANGELOG update.

Closes UFO-10

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test:run`

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

## Release Notes

This release includes:
- MiniMax provider preset upgrade to M3 default model
- Cross-platform CCometixLine status command generation
- DeepWiki MCP configuration typing, tests, and multilingual documentation updates

⚠️ **IMPORTANT**: After merge, GitHub Actions will automatically:
- Create release tag
- Publish to npm
- Generate GitHub Release

🤖 Generated by /zcf-release command

Made with [Cursor](https://cursor.com)