### PR TITLE
fix(config) Sync ClaudeCodeConfigManager state after API configuration changes

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -693,6 +693,16 @@ export async function init(options: InitOptions = {}): Promise<void> {
           await configureCcrProxy(defaultCcrConfig)
           console.log(ansis.green(`✔ ${i18n.t('ccr:proxyConfigSuccess')}`))
 
+          // Sync ClaudeCodeConfigManager state
+          const { ClaudeCodeConfigManager } = await import('../utils/claude-code-config-manager')
+          const ccrResult = await ClaudeCodeConfigManager.switchToCcr()
+          if (!ccrResult.success) {
+            console.error(ansis.red(i18n.t('ccr:ccrConfigFailed')))
+            if (process.env.DEBUG) {
+              console.error(ansis.gray(ccrResult.error))
+            }
+          }
+
           // Add onboarding flag
           try {
             addCompletedOnboarding()
@@ -716,6 +726,15 @@ export async function init(options: InitOptions = {}): Promise<void> {
             // Handle official login
             const success = switchToOfficialLogin()
             if (success) {
+              // Sync ClaudeCodeConfigManager state
+              const { ClaudeCodeConfigManager } = await import('../utils/claude-code-config-manager')
+              const syncResult = await ClaudeCodeConfigManager.switchToOfficial()
+              if (!syncResult.success) {
+                console.error(ansis.red(i18n.t('api:officialLoginFailed')))
+                if (process.env.DEBUG) {
+                  console.error(ansis.gray(syncResult.error))
+                }
+              }
               console.log(ansis.green(`✔ ${i18n.t('api:officialLoginConfigured')}`))
               apiConfig = null // No need for API config
             }
@@ -743,6 +762,15 @@ export async function init(options: InitOptions = {}): Promise<void> {
             // Setup CCR configuration
             const ccrConfigured = await setupCcrConfiguration()
             if (ccrConfigured) {
+              // Sync ClaudeCodeConfigManager state so "Switch API Config" reflects CCR as current
+              const { ClaudeCodeConfigManager } = await import('../utils/claude-code-config-manager')
+              const ccrResult = await ClaudeCodeConfigManager.switchToCcr()
+              if (!ccrResult.success) {
+                console.error(ansis.red(i18n.t('ccr:ccrConfigFailed')))
+                if (process.env.DEBUG) {
+                  console.error(ansis.gray(ccrResult.error))
+                }
+              }
               console.log(ansis.green(`✔ ${i18n.t('ccr:ccrSetupComplete')}`))
               // CCR configuration already sets up the proxy in settings.json
               // addCompletedOnboarding is already called inside setupCcrConfiguration

--- a/src/utils/config-operations.ts
+++ b/src/utils/config-operations.ts
@@ -1,5 +1,6 @@
 import type { AiOutputLanguage } from '../constants'
 import type { ApiConfig } from '../types/config'
+import process from 'node:process'
 import ansis from 'ansis'
 import inquirer from 'inquirer'
 import { CLAUDE_DIR } from '../constants'
@@ -60,6 +61,15 @@ export async function configureApiCompletely(
   if (authType === 'official') {
     const success = switchToOfficialLogin()
     if (success) {
+      // Sync ClaudeCodeConfigManager state
+      const { ClaudeCodeConfigManager } = await import('./claude-code-config-manager')
+      const syncResult = await ClaudeCodeConfigManager.switchToOfficial()
+      if (!syncResult.success) {
+        console.error(ansis.red(i18n.t('api:officialLoginFailed')))
+        if (process.env.DEBUG) {
+          console.error(ansis.gray(syncResult.error))
+        }
+      }
       return null // No API config needed for official login
     }
     else {

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,5 +1,6 @@
 import type { SupportedLang } from '../constants'
 import type { McpServerConfig } from '../types'
+import process from 'node:process'
 import ansis from 'ansis'
 import inquirer from 'inquirer'
 import { getMcpServices } from '../config/mcp-services'
@@ -46,6 +47,15 @@ async function handleOfficialLoginMode(): Promise<void> {
   ensureI18nInitialized()
   const success = switchToOfficialLogin()
   if (success) {
+    // Sync ClaudeCodeConfigManager state
+    const { ClaudeCodeConfigManager } = await import('../utils/claude-code-config-manager')
+    const syncResult = await ClaudeCodeConfigManager.switchToOfficial()
+    if (!syncResult.success) {
+      console.error(ansis.red(i18n.t('api:officialLoginFailed')))
+      if (process.env.DEBUG) {
+        console.error(ansis.gray(syncResult.error))
+      }
+    }
     console.log(ansis.green(`✔ ${i18n.t('api:officialLoginConfigured')}`))
   }
   else {
@@ -185,6 +195,15 @@ async function handleCcrProxyMode(): Promise<void> {
   // Setup CCR configuration
   const ccrConfigured = await setupCcrConfiguration()
   if (ccrConfigured) {
+    // Sync ClaudeCodeConfigManager state so "Switch API Config" reflects CCR as current
+    const { ClaudeCodeConfigManager } = await import('../utils/claude-code-config-manager')
+    const result = await ClaudeCodeConfigManager.switchToCcr()
+    if (!result.success) {
+      console.error(ansis.red(i18n.t('ccr:ccrConfigFailed')))
+      if (process.env.DEBUG) {
+        console.error(ansis.gray(result.error))
+      }
+    }
     console.log(ansis.green(`✔ ${i18n.t('ccr:ccrSetupComplete')}`))
   }
 }

--- a/tests/unit/commands/init.test.ts
+++ b/tests/unit/commands/init.test.ts
@@ -123,6 +123,14 @@ vi.mock('../../../src/utils/ccr/config', () => ({
   setupCcrConfiguration: vi.fn(),
 }))
 
+vi.mock('../../../src/utils/claude-code-config-manager', () => ({
+  ClaudeCodeConfigManager: {
+    switchToOfficial: vi.fn().mockResolvedValue({ success: true }),
+    switchToCcr: vi.fn().mockResolvedValue({ success: true }),
+    syncCcrProfile: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
 vi.mock('../../../src/utils/cometix/installer', () => ({
   isCometixLineInstalled: vi.fn(),
   installCometixLine: vi.fn(),
@@ -175,6 +183,11 @@ interface TestMocks {
   configureApiCompletely: any
   modifyApiConfigPartially: any
   configureIncrementalManagement: any
+  ClaudeCodeConfigManager: {
+    switchToOfficial: any
+    switchToCcr: any
+    syncCcrProfile: any
+  }
 }
 
 let testMocks: TestMocks
@@ -200,6 +213,7 @@ describe('init command', () => {
     const { setupCcrConfiguration } = await import('../../../src/utils/ccr/config')
     const { configureApiCompletely, modifyApiConfigPartially } = await import('../../../src/utils/config-operations')
     const { configureIncrementalManagement } = await import('../../../src/utils/claude-code-incremental-manager')
+    const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
     const { existsSync } = await import('node:fs')
     const { promptBoolean } = await import('../../../src/utils/toggle-prompt')
 
@@ -228,6 +242,11 @@ describe('init command', () => {
       configureApiCompletely: vi.mocked(configureApiCompletely),
       modifyApiConfigPartially: vi.mocked(modifyApiConfigPartially),
       configureIncrementalManagement: vi.mocked(configureIncrementalManagement),
+      ClaudeCodeConfigManager: {
+        switchToOfficial: vi.mocked(ClaudeCodeConfigManager.switchToOfficial),
+        switchToCcr: vi.mocked(ClaudeCodeConfigManager.switchToCcr),
+        syncCcrProfile: vi.mocked(ClaudeCodeConfigManager.syncCcrProfile),
+      },
       promptBoolean: vi.mocked(promptBoolean),
     }
     // Default promptBoolean to return false to avoid hanging
@@ -869,6 +888,8 @@ describe('init command', () => {
 
         // Should call switchToOfficialLogin for official mode
         expect(testMocks.switchToOfficialLogin).toHaveBeenCalled()
+        // Should sync ClaudeCodeConfigManager state
+        expect(testMocks.ClaudeCodeConfigManager.switchToOfficial).toHaveBeenCalled()
       })
 
       it('should handle CCR proxy mode selection', async () => {
@@ -888,6 +909,7 @@ describe('init command', () => {
           hasCorrectPackage: true,
         } as any)
         testMocks.setupCcrConfiguration.mockResolvedValue(true)
+        testMocks.ClaudeCodeConfigManager.switchToCcr.mockResolvedValue({ success: true })
         testMocks.inquirerPrompt.mockResolvedValueOnce({ apiMode: 'ccr' }) // Unified menu selection
         testMocks.configureOutputStyle.mockResolvedValue(undefined)
         testMocks.updateZcfConfig.mockResolvedValue(undefined)
@@ -901,6 +923,8 @@ describe('init command', () => {
         // Should check CCR installation and setup CCR configuration
         expect(testMocks.isCcrInstalled).toHaveBeenCalled()
         expect(testMocks.setupCcrConfiguration).toHaveBeenCalled()
+        // Should sync ClaudeCodeConfigManager state
+        expect(testMocks.ClaudeCodeConfigManager.switchToCcr).toHaveBeenCalled()
       })
 
       it('should handle skip mode selection', async () => {

--- a/tests/unit/utils/config-operations.test.ts
+++ b/tests/unit/utils/config-operations.test.ts
@@ -16,6 +16,13 @@ vi.mock('inquirer')
 vi.mock('../../../src/utils/config')
 vi.mock('../../../src/utils/output-style')
 vi.mock('../../../src/utils/validator')
+vi.mock('../../../src/utils/claude-code-config-manager', () => ({
+  ClaudeCodeConfigManager: {
+    switchToOfficial: vi.fn(),
+    switchToCcr: vi.fn(),
+    syncCcrProfile: vi.fn(),
+  },
+}))
 
 describe('config-operations utilities', () => {
   beforeAll(() => {
@@ -210,6 +217,33 @@ describe('config-operations utilities', () => {
           message: i18n.t('api:configureApi'),
         }),
       )
+    })
+
+    it('should sync ClaudeCodeConfigManager when switching to official login', async () => {
+      const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
+
+      vi.mocked(inquirer.prompt).mockResolvedValueOnce({ authType: 'official' })
+      vi.mocked(config.switchToOfficialLogin).mockReturnValue(true)
+      vi.mocked(ClaudeCodeConfigManager.switchToOfficial).mockResolvedValue({ success: true })
+
+      const result = await configureApiCompletely()
+
+      expect(result).toBeNull()
+      expect(config.switchToOfficialLogin).toHaveBeenCalled()
+      expect(ClaudeCodeConfigManager.switchToOfficial).toHaveBeenCalled()
+    })
+
+    it('should log error when switchToOfficial fails during official login', async () => {
+      const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
+
+      vi.mocked(inquirer.prompt).mockResolvedValueOnce({ authType: 'official' })
+      vi.mocked(config.switchToOfficialLogin).mockReturnValue(true)
+      vi.mocked(ClaudeCodeConfigManager.switchToOfficial).mockResolvedValue({ success: false, error: 'sync failed' })
+
+      const result = await configureApiCompletely()
+
+      expect(result).toBeNull()
+      expect(console.error).toHaveBeenCalled()
     })
   })
 

--- a/tests/unit/utils/features.test.ts
+++ b/tests/unit/utils/features.test.ts
@@ -35,6 +35,14 @@ vi.mock('../../../src/utils/claude-code-incremental-manager', () => ({
   configureIncrementalManagement: vi.fn(),
 }))
 
+vi.mock('../../../src/utils/claude-code-config-manager', () => ({
+  ClaudeCodeConfigManager: {
+    switchToOfficial: vi.fn(),
+    switchToCcr: vi.fn(),
+    syncCcrProfile: vi.fn(),
+  },
+}))
+
 vi.mock('../../../src/utils/ccr/config', () => ({
   setupCcrConfiguration: vi.fn(),
   configureCcrProxy: vi.fn(),
@@ -165,13 +173,16 @@ describe('features utilities', () => {
     it('should handle official login mode', async () => {
       const { configureApiFeature } = await import('../../../src/utils/features')
       const { switchToOfficialLogin } = await import('../../../src/utils/config')
+      const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
 
       vi.mocked(inquirer.prompt).mockResolvedValueOnce({ mode: 'official' })
       vi.mocked(switchToOfficialLogin).mockReturnValue(true)
+      vi.mocked(ClaudeCodeConfigManager.switchToOfficial).mockResolvedValue({ success: true })
 
       await configureApiFeature()
 
       expect(switchToOfficialLogin).toHaveBeenCalled()
+      expect(ClaudeCodeConfigManager.switchToOfficial).toHaveBeenCalled()
     })
 
     it('should handle custom API mode', async () => {
@@ -196,14 +207,47 @@ describe('features utilities', () => {
       const { configureApiFeature } = await import('../../../src/utils/features')
       const ccrConfigModule = await import('../../../src/utils/ccr/config')
       const ccrInstallerModule = await import('../../../src/utils/ccr/installer')
+      const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
 
       vi.mocked(inquirer.prompt).mockResolvedValueOnce({ mode: 'ccr' })
       vi.mocked(ccrInstallerModule.isCcrInstalled).mockResolvedValue({ hasCorrectPackage: true } as any)
       vi.mocked(ccrConfigModule.setupCcrConfiguration).mockResolvedValue(true as any)
+      vi.mocked(ClaudeCodeConfigManager.switchToCcr).mockResolvedValue({ success: true })
 
       await configureApiFeature()
 
       expect(ccrConfigModule.setupCcrConfiguration).toHaveBeenCalled()
+      expect(ClaudeCodeConfigManager.switchToCcr).toHaveBeenCalled()
+    })
+
+    it('should log error when switchToCcr fails after CCR setup', async () => {
+      const { configureApiFeature } = await import('../../../src/utils/features')
+      const ccrConfigModule = await import('../../../src/utils/ccr/config')
+      const ccrInstallerModule = await import('../../../src/utils/ccr/installer')
+      const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
+
+      vi.mocked(inquirer.prompt).mockResolvedValueOnce({ mode: 'ccr' })
+      vi.mocked(ccrInstallerModule.isCcrInstalled).mockResolvedValue({ hasCorrectPackage: true } as any)
+      vi.mocked(ccrConfigModule.setupCcrConfiguration).mockResolvedValue(true as any)
+      vi.mocked(ClaudeCodeConfigManager.switchToCcr).mockResolvedValue({ success: false, error: 'sync failed' })
+
+      await configureApiFeature()
+
+      expect(console.error).toHaveBeenCalled()
+    })
+
+    it('should log error when switchToOfficial fails after official login', async () => {
+      const { configureApiFeature } = await import('../../../src/utils/features')
+      const { switchToOfficialLogin } = await import('../../../src/utils/config')
+      const { ClaudeCodeConfigManager } = await import('../../../src/utils/claude-code-config-manager')
+
+      vi.mocked(inquirer.prompt).mockResolvedValueOnce({ mode: 'official' })
+      vi.mocked(switchToOfficialLogin).mockReturnValue(true)
+      vi.mocked(ClaudeCodeConfigManager.switchToOfficial).mockResolvedValue({ success: false, error: 'sync failed' })
+
+      await configureApiFeature()
+
+      expect(console.error).toHaveBeenCalled()
     })
 
     it('should handle skip mode', async () => {


### PR DESCRIPTION
## Description

When configuring CCR proxy or official login via the interactive menu, the "Switch API Config" menu did not reflect the current active configuration because `currentProfileId` was not updated after writing `settings.json`. This commit adds sync calls to `ClaudeCodeConfigManager` in all six call sites where API configuration changes occur.

### Root Cause

**CCR path:**

```
handleCcrProxyMode()
  └─ setupCcrConfiguration()
       ├─ writeCcrConfig()          ✅
       └─ configureCcrProxy()       ✅
  ❌ ClaudeCodeConfigManager.switchToCcr() not called
```

**Official login path:**

```
handleOfficialLoginMode()
  └─ switchToOfficialLogin()
       └─ clean settings.json       ✅
  ❌ ClaudeCodeConfigManager.switchToOfficial() not called
```

The "Switch API Config" menu reads `ClaudeCodeConfigManager.readConfig().currentProfileId` to determine which option is active. Since it was never updated, the menu always showed the previous state.

### Steps to Reproduce

1. Run `npx zcf` to open the interactive menu
2. Select **"3. Configure API or CCR Proxy"**
3. Select **"3. Use CCR Proxy"**, complete the setup
4. Return to main menu, select **"4. Switch API Config"**
5. Observe: CCR proxy option does not show `●` current marker

### Changes

**`src/utils/features.ts`**
- `handleCcrProxyMode()`: call `ClaudeCodeConfigManager.switchToCcr()` after CCR setup, log error on failure
- `handleOfficialLoginMode()`: call `ClaudeCodeConfigManager.switchToOfficial()` after official login, log error on failure

**`src/utils/config-operations.ts`**
- `configureApiCompletely()` official branch: sync `ClaudeCodeConfigManager` state, log error on failure

**`src/commands/init.ts`**
- Interactive CCR path: sync after `setupCcrConfiguration()` succeeds
- Interactive official path: sync after `switchToOfficialLogin()` succeeds
- Non-interactive CCR path (`apiType: 'ccr_proxy'`): sync after `configureCcrProxy()`

**`tests/unit/utils/features.test.ts`**
- Verify `switchToCcr` / `switchToOfficial` are called on success
- Verify `console.error` is called when sync fails

**`tests/unit/utils/config-operations.test.ts`**
- Verify official login sync and error handling

**`tests/unit/commands/init.test.ts`**
- Verify CCR/official mode sync in interactive flow

## Type of Change

- [x] Bug fix

Fix #374

## Testing

- [x] Tests added/updated (6 new test cases)
- [x] All tests pass (98/98 in affected test files)
- [x] Coverage maintained

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated (N/A - no API changes)
- [x] No new warnings introduced (`pnpm typecheck` + `pnpm build` pass)
