### PR TITLE
feat(api): add MiniMax Codex preset

### DIFF
--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -209,11 +209,16 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
   {
     id: 'minimax',
     name: 'MiniMax',
-    supportedCodeTools: ['claude-code'],
+    supportedCodeTools: ['claude-code', 'codex'],
     claudeCode: {
-      baseUrl: 'https://api.minimax.io/anthropic',
+      baseUrl: 'https://api.minimax.io/anthropic/v1',
       authType: 'auth_token',
       defaultModels: ['MiniMax-M3', 'MiniMax-M2.7-highspeed'],
+    },
+    codex: {
+      baseUrl: 'https://api.minimax.io/v1',
+      wireApi: 'responses',
+      defaultModel: 'MiniMax-M3',
     },
     description: 'MiniMax API Service',
   },

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -85,9 +85,13 @@ describe('aPI Provider Configuration', () => {
       expect(provider).toBeDefined()
       expect(provider!.name).toBe('MiniMax')
       expect(provider!.supportedCodeTools).toContain('claude-code')
-      expect(provider!.claudeCode?.baseUrl).toBe('https://api.minimax.io/anthropic')
+      expect(provider!.supportedCodeTools).toContain('codex')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.minimax.io/anthropic/v1')
       expect(provider!.claudeCode?.authType).toBe('auth_token')
       expect(provider!.claudeCode?.defaultModels).toEqual(['MiniMax-M3', 'MiniMax-M2.7-highspeed'])
+      expect(provider!.codex?.baseUrl).toBe('https://api.minimax.io/v1')
+      expect(provider!.codex?.wireApi).toBe('responses')
+      expect(provider!.codex?.defaultModel).toBe('MiniMax-M3')
     })
 
     it('bailian-coding provider should use lowercase glm-5 default model', () => {


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax's OpenAI-compatible endpoint for Codex provider selection.
- Update MiniMax's Claude Code endpoint to the `/anthropic/v1` Anthropic-compatible API path.
- Extend provider registry tests to cover MiniMax Codex defaults.

## Checks
- `git add -A -N && git diff HEAD | grep -E "$SECRET_RE"` (no matches)
- `pnpm --dir /root/octopatch-4/work/repos/UfoMiao__zcf test:run -- tests/unit/config/api-providers.test.ts`
- `pnpm --dir /root/octopatch-4/work/repos/UfoMiao__zcf typecheck`
- commit hook: `pnpm i --frozen-lockfile --ignore-scripts --offline`, `lint-staged` (`pnpm lint`), `pnpm typecheck`