### PR TITLE
🚀 Release v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 3.7.0
+
+### Minor Changes
+
+- ## New Features
+  - Migrate ZCF templates from commands to skills architecture with unified skills installer
+  - Add MiniMax Codex API provider preset
+  - Add skills-installer utility for symlink-based Claude Code and Codex skill deployment
+
+  ## 新功能
+  - 将 ZCF 模板从 commands 迁移至 skills 架构，并引入统一的 skills 安装器
+  - 新增 MiniMax Codex API 提供商预设
+  - 新增 skills-installer 工具，支持 Claude Code 与 Codex 的符号链接式 skill 部署
+
+  ## Optimization
+  - Route Codex workflow installation through the skills installer for consistent deployment
+  - Use symlink install for Claude Code skills via the skills CLI
+  - Remove bmad from ZCF development configuration to reduce project footprint
+  - Unify command-to-skills naming across uninstall flow and documentation
+
+  ## 优化
+  - Codex 工作流安装改由 skills 安装器统一处理，确保部署一致性
+  - Claude Code 通过 skills CLI 使用符号链接方式安装 skill
+  - 从 ZCF 开发配置中移除 bmad，精简项目体积
+  - 统一卸载流程与文档中的 command→skills 命名
+
+  ## Fixes
+  - Update sponsor links for code0 and Claude API across multilingual README files
+
+  ## 修复
+  - 更新 code0 与 Claude API 赞助商链接，覆盖多语言 README 文件
+
 ## 3.6.10
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zcf",
   "type": "module",
-  "version": "3.6.10",
+  "version": "3.7.0",
   "packageManager": "pnpm@10.17.1",
   "description": "Zero-Config Code Flow - One-click configuration tool for Code Cli",
   "author": {


### PR DESCRIPTION
## Description

Release version v3.7.0 with automated version bump and CHANGELOG update.

This release migrates ZCF templates from commands to skills architecture, adds MiniMax Codex preset, and includes various optimizations and fixes. Please review CHANGELOG.md for details.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests pass
- [x] Coverage maintained

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

## Release Notes

⚠️ **IMPORTANT**: After merge, GitHub Actions will automatically:
- Create release tag
- Publish to npm  
- Generate GitHub Release

🤖 Generated by /zcf-release command