### PR TITLE
fix(codex): stop overwriting CLAUDE.md during init (zcf#398)

### DIFF
--- a/src/utils/code-tools/codex-configure.ts
+++ b/src/utils/code-tools/codex-configure.ts
@@ -6,7 +6,7 @@ import { ensureI18nInitialized, i18n } from '../../i18n'
 import { selectMcpServices } from '../mcp-selector'
 import { getSystemRoot, isWindows } from '../platform'
 import { updateZcfConfig } from '../zcf-config'
-import { backupCodexComplete, getBackupMessage, readCodexConfig } from './codex'
+import { backupCodexTargets, getBackupMessage, readCodexConfig } from './codex'
 import { applyCodexPlatformCommand } from './codex-platform'
 import { batchUpdateCodexMcpServices } from './codex-toml-updater'
 
@@ -15,9 +15,6 @@ export async function configureCodexMcp(options?: CodexFullInitOptions): Promise
 
   const { skipPrompt = false } = options ?? {}
   const existingConfig = readCodexConfig()
-  const backupPath = backupCodexComplete()
-  if (backupPath)
-    console.log(ansis.gray(getBackupMessage(backupPath)))
 
   // Skip-prompt 模式：自动安装无 API Key 的默认 MCP
   if (skipPrompt) {
@@ -105,6 +102,10 @@ export async function configureCodexMcp(options?: CodexFullInitOptions): Promise
     })
 
     // Use targeted MCP updates - preserves existing SSE-type services
+    const backupPath = backupCodexTargets(['config'])
+    if (backupPath)
+      console.log(ansis.gray(getBackupMessage(backupPath)))
+
     batchUpdateCodexMcpServices(finalServices)
     updateZcfConfig({ codeToolType: 'codex' })
     console.log(ansis.green(i18n.t('codex:mcpConfigured')))
@@ -140,6 +141,10 @@ export async function configureCodexMcp(options?: CodexFullInitOptions): Promise
     })
 
     // Use targeted MCP updates - preserves existing SSE-type services
+    const backupPath = backupCodexTargets(['config'])
+    if (backupPath)
+      console.log(ansis.gray(getBackupMessage(backupPath)))
+
     batchUpdateCodexMcpServices(preserved)
     updateZcfConfig({ codeToolType: 'codex' })
     return
@@ -225,6 +230,10 @@ export async function configureCodexMcp(options?: CodexFullInitOptions): Promise
   })
 
   // Use targeted MCP updates - preserves existing SSE-type services
+  const backupPath = backupCodexTargets(['config'])
+  if (backupPath)
+    console.log(ansis.gray(getBackupMessage(backupPath)))
+
   batchUpdateCodexMcpServices(finalServices)
 
   updateZcfConfig({ codeToolType: 'codex' })

--- a/src/utils/code-tools/codex-provider-manager.ts
+++ b/src/utils/code-tools/codex-provider-manager.ts
@@ -1,6 +1,6 @@
 import type { CodexProvider } from './codex'
 import { ensureI18nInitialized, i18n } from '../../i18n'
-import { backupCodexComplete, readCodexConfig, writeAuthFile } from './codex'
+import { backupCodexTargets, readCodexConfig, writeAuthFile } from './codex'
 
 export interface ProviderOperationResult {
   success: boolean
@@ -49,7 +49,7 @@ export async function addProviderToExisting(
     // Create backup only when config already exists
     let backupPath: string | undefined
     if (existingConfig) {
-      const backup = backupCodexComplete()
+      const backup = backupCodexTargets(['config', 'auth'])
       if (!backup) {
         return {
           success: false,
@@ -131,7 +131,7 @@ export async function editExistingProvider(
     }
 
     // Create backup
-    const backupPath = backupCodexComplete()
+    const backupPath = backupCodexTargets(['config', 'auth'])
     if (!backupPath) {
       return {
         success: false,
@@ -225,7 +225,7 @@ export async function deleteProviders(
     }
 
     // Create backup
-    const backupPath = backupCodexComplete()
+    const backupPath = backupCodexTargets(['config', 'auth'])
     if (!backupPath) {
       return {
         success: false,

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -12,7 +12,6 @@ import { x } from 'tinyexec'
 // Removed MCP config imports; MCP configuration moved to codex-configure.ts
 import { AI_OUTPUT_LANGUAGES, CODEX_AGENTS_FILE, CODEX_AUTH_FILE, CODEX_CONFIG_FILE, CODEX_DIR, CODEX_PROMPTS_DIR, SUPPORTED_LANGS, ZCF_CONFIG_FILE } from '../../constants'
 import { ensureI18nInitialized, format, i18n } from '../../i18n'
-import { applyAiLanguageDirective } from '../config'
 import { copyDir, copyFile, ensureDir, exists, readFile, writeFile } from '../fs-operations'
 import { readJsonConfig, writeJsonConfig } from '../json-config'
 import { normalizeTomlPath, wrapCommandWithSudo } from '../platform'
@@ -25,8 +24,10 @@ import { readDefaultTomlConfig, readZcfConfig, updateTomlConfig, updateZcfConfig
 import { detectConfigManagementMode } from './codex-config-detector'
 import { configureCodexMcp } from './codex-configure'
 
-// Cache to avoid repeated backups in skip-prompt mode
-let cachedSkipPromptBackup: string | null = null
+// Cache backup directory to avoid repeated backups in skip-prompt mode
+let cachedSkipPromptBackupDir: string | null = null
+
+export type CodexBackupTarget = 'config' | 'auth' | 'agents' | 'prompts'
 
 // Public export for easy reuse and testing
 export { applyCodexPlatformCommand } from './codex-platform'
@@ -200,91 +201,84 @@ export function createBackupDirectory(timestamp: string): string {
 }
 
 export function backupCodexFiles(): string | null {
-  if (!exists(CODEX_DIR))
-    return null
-
-  // Skip-prompt模式：只在首次调用时创建备份，其余复用
-  if (process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP === 'true' && cachedSkipPromptBackup)
-    return cachedSkipPromptBackup
-
-  const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss')
-  const backupDir = createBackupDirectory(timestamp)
-
-  const tmpDir = join(CODEX_DIR, 'tmp')
-  const filter = (path: string): boolean => {
-    // Skip backup directories and temp directory (runtime artifacts, dangling symlinks)
-    // Use precise path matching to avoid false positives like 'tmp-config.toml'
-    return !path.includes('/backup') && !path.startsWith(tmpDir)
-  }
-
-  copyDir(CODEX_DIR, backupDir, { filter })
-  if (process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP === 'true')
-    cachedSkipPromptBackup = backupDir
-
-  return backupDir
+  return backupCodexTargets(['config', 'auth', 'agents', 'prompts'])
 }
 
 /**
- * Backup complete Codex directory with all configuration files
- * This provides the same comprehensive backup functionality as Claude Code
- *
- * Note: This is an alias for backupCodexFiles() to maintain API consistency
- * while following DRY principles (Don't Repeat Yourself)
+ * Backup only the Codex files that will be modified.
+ * In skip-prompt mode, reuses the same backup directory across calls.
+ */
+export function backupCodexTargets(targets: CodexBackupTarget[]): string | null {
+  const entries: Array<{ source: string, relativePath: string, isDir?: boolean }> = []
+
+  for (const target of targets) {
+    switch (target) {
+      case 'config':
+        if (exists(CODEX_CONFIG_FILE))
+          entries.push({ source: CODEX_CONFIG_FILE, relativePath: 'config.toml' })
+        break
+      case 'auth':
+        if (exists(CODEX_AUTH_FILE))
+          entries.push({ source: CODEX_AUTH_FILE, relativePath: 'auth.json' })
+        break
+      case 'agents':
+        if (exists(CODEX_AGENTS_FILE))
+          entries.push({ source: CODEX_AGENTS_FILE, relativePath: 'AGENTS.md' })
+        break
+      case 'prompts':
+        if (exists(CODEX_PROMPTS_DIR))
+          entries.push({ source: CODEX_PROMPTS_DIR, relativePath: 'prompts', isDir: true })
+        break
+    }
+  }
+
+  if (entries.length === 0)
+    return null
+
+  try {
+    let backupDir: string
+    if (process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP === 'true' && cachedSkipPromptBackupDir) {
+      backupDir = cachedSkipPromptBackupDir
+    }
+    else {
+      const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss')
+      backupDir = createBackupDirectory(timestamp)
+      if (process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP === 'true')
+        cachedSkipPromptBackupDir = backupDir
+    }
+
+    for (const entry of entries) {
+      const dest = join(backupDir, entry.relativePath)
+      if (entry.isDir)
+        copyDir(entry.source, dest)
+      else
+        copyFile(entry.source, dest)
+    }
+
+    return join(backupDir, entries[0].relativePath)
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * @deprecated Prefer backupCodexTargets() for targeted backups.
  */
 export function backupCodexComplete(): string | null {
   return backupCodexFiles()
 }
 
 export function backupCodexConfig(): string | null {
-  if (!exists(CODEX_CONFIG_FILE))
-    return null
-
-  try {
-    const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss')
-    const backupDir = createBackupDirectory(timestamp)
-    const backupPath = join(backupDir, 'config.toml')
-    copyFile(CODEX_CONFIG_FILE, backupPath)
-    return backupPath
-  }
-  catch {
-    return null
-  }
+  return backupCodexTargets(['config'])
 }
 
 export function backupCodexAgents(): string | null {
-  if (process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP === 'true' && cachedSkipPromptBackup)
-    return cachedSkipPromptBackup
-  if (!exists(CODEX_AGENTS_FILE))
-    return null
-
-  try {
-    const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss')
-    const backupDir = createBackupDirectory(timestamp)
-    const backupPath = join(backupDir, 'AGENTS.md')
-    copyFile(CODEX_AGENTS_FILE, backupPath)
-    return backupPath
-  }
-  catch {
-    return null
-  }
+  return backupCodexTargets(['agents'])
 }
 
 export function backupCodexPrompts(): string | null {
-  if (process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP === 'true' && cachedSkipPromptBackup)
-    return cachedSkipPromptBackup
-  if (!exists(CODEX_PROMPTS_DIR))
-    return null
-
-  try {
-    const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss')
-    const backupDir = createBackupDirectory(timestamp)
-    const backupPath = join(backupDir, 'prompts')
-    copyDir(CODEX_PROMPTS_DIR, backupPath)
-    return backupPath
-  }
-  catch {
-    return null
-  }
+  return backupCodexTargets(['prompts'])
 }
 
 export function getBackupMessage(path: string | null): string {
@@ -1121,7 +1115,7 @@ export async function runCodexWorkflowImportWithLanguageSelection(
 
   // Step 2: Save AI output language to global config
   updateZcfConfig({ aiOutputLang })
-  applyAiLanguageDirective(aiOutputLang)
+  // Language directive is applied to Codex AGENTS.md via ensureCodexAgentsLanguageDirective
 
   // Step 3: Continue with original workflow (system prompt + workflow selection)
   await runCodexSystemPromptSelection(skipPrompt)
@@ -1303,7 +1297,7 @@ async function applyCustomApiConfig(customApiConfig: NonNullable<CodexFullInitOp
   const { type, token, baseUrl, model } = customApiConfig
 
   // Always backup existing config before modification
-  const backupPath = backupCodexComplete()
+  const backupPath = backupCodexTargets(['config', 'auth'])
   if (backupPath) {
     console.log(ansis.gray(getBackupMessage(backupPath)))
   }
@@ -1389,6 +1383,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
   const hasProviders = existingConfig?.providers && existingConfig.providers.length > 0
 
   const modeChoices = [
+    { name: i18n.t('api:skipApi'), value: 'skip' },
     { name: i18n.t('codex:apiModeOfficial'), value: 'official' },
     { name: i18n.t('codex:apiModeCustom'), value: 'custom' },
   ]
@@ -1398,7 +1393,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
     modeChoices.push({ name: i18n.t('codex:configSwitchMode'), value: 'switch' })
   }
 
-  const { mode } = await inquirer.prompt<{ mode: 'official' | 'custom' | 'switch' }>([{
+  const { mode } = await inquirer.prompt<{ mode: 'official' | 'custom' | 'switch' | 'skip' }>([{
     type: 'list',
     name: 'mode',
     message: i18n.t('codex:apiModePrompt'),
@@ -1408,6 +1403,11 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
 
   if (!mode) {
     console.log(ansis.yellow(i18n.t('common:cancelled')))
+    return
+  }
+
+  if (mode === 'skip') {
+    console.log(ansis.yellow(i18n.t('common:skip')))
     return
   }
 
@@ -1468,7 +1468,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
   }
 
   // Always backup existing config before modification
-  const backupPath = backupCodexComplete()
+  const backupPath = backupCodexTargets(['config', 'auth'])
   if (backupPath) {
     console.log(ansis.gray(getBackupMessage(backupPath)))
   }
@@ -1942,7 +1942,7 @@ export async function switchCodexProvider(providerId: string): Promise<boolean> 
   }
 
   // Create backup before modification
-  const backupPath = backupCodexComplete()
+  const backupPath = backupCodexTargets(['config'])
   if (backupPath) {
     console.log(ansis.gray(getBackupMessage(backupPath)))
   }
@@ -1977,7 +1977,7 @@ export async function switchToOfficialLogin(): Promise<boolean> {
   }
 
   // Create backup before modification
-  const backupPath = backupCodexComplete()
+  const backupPath = backupCodexTargets(['config', 'auth'])
   if (backupPath) {
     console.log(ansis.gray(getBackupMessage(backupPath)))
   }
@@ -2041,7 +2041,7 @@ export async function switchToProvider(providerId: string): Promise<boolean> {
   }
 
   // Create backup before modification
-  const backupPath = backupCodexComplete()
+  const backupPath = backupCodexTargets(['config', 'auth'])
   if (backupPath) {
     console.log(ansis.gray(getBackupMessage(backupPath)))
   }

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -329,16 +329,19 @@ export async function resolveSystemPromptStyle(
     type: 'list',
     name: 'systemPrompt',
     message: i18n.t('codex:systemPromptPrompt'),
-    choices: addNumbersToChoices(availablePrompts.map(style => ({
-      name: `${style.name} - ${ansis.gray(style.description)}`,
-      value: style.id,
-    }))),
+    choices: addNumbersToChoices([
+      ...availablePrompts.map(style => ({
+        name: `${style.name} - ${ansis.gray(style.description)}`,
+        value: style.id,
+      })),
+      { name: i18n.t('common:skip'), value: 'skip' },
+    ]),
     default: 'engineer-professional', // Default to engineer-professional
   }])
 
-  if (!systemPrompt) {
-    console.log(ansis.yellow(i18n.t('common:cancelled')))
-    process.exit(0)
+  if (!systemPrompt || systemPrompt === 'skip') {
+    console.log(ansis.yellow(i18n.t('common:skip')))
+    return ''
   }
 
   return systemPrompt

--- a/tests/unit/utils/code-tools/codex-backup.test.ts
+++ b/tests/unit/utils/code-tools/codex-backup.test.ts
@@ -39,73 +39,41 @@ describe('codex backup mechanism', () => {
   })
 
   describe('backupCodexFiles', () => {
-    it('should create backup with timestamp when .codex directory exists', async () => {
-      // Arrange
+    it('should create targeted backup when codex files exist', async () => {
       mockExists.mockReturnValue(true)
 
-      // Act
       const { backupCodexFiles } = await import('../../../../src/utils/code-tools/codex')
       const result = backupCodexFiles()
 
-      // Assert
       const expectedBackupDir = join(BACKUP_BASE_DIR, 'backup_2024-01-01_14-30-00')
-      expect(result).toBe(expectedBackupDir)
+      expect(result).toBe(join(expectedBackupDir, 'config.toml'))
       expect(mockEnsureDir).toHaveBeenCalledWith(expectedBackupDir)
-      expect(mockCopyDir).toHaveBeenCalledWith(
-        CODEX_DIR,
-        expectedBackupDir,
-        expect.objectContaining({
-          filter: expect.any(Function),
-        }),
-      )
+      expect(mockCopyFile).toHaveBeenCalled()
+      expect(mockCopyDir).toHaveBeenCalled()
     })
 
-    it('should return null when .codex directory does not exist', async () => {
-      // Arrange
+    it('should return null when no codex files exist', async () => {
       mockExists.mockReturnValue(false)
 
-      // Act
       const { backupCodexFiles } = await import('../../../../src/utils/code-tools/codex')
       const result = backupCodexFiles()
 
-      // Assert
       expect(result).toBeNull()
       expect(mockEnsureDir).not.toHaveBeenCalled()
+      expect(mockCopyFile).not.toHaveBeenCalled()
       expect(mockCopyDir).not.toHaveBeenCalled()
     })
 
-    it('should filter out backup directory when copying', async () => {
-      // Arrange
-      mockExists.mockReturnValue(true)
-      let filterFunction: ((path: string) => boolean) | undefined
-
-      mockCopyDir.mockImplementation((_src, _dest, options) => {
-        filterFunction = options?.filter
-      })
-
-      // Act
-      const { backupCodexFiles } = await import('../../../../src/utils/code-tools/codex')
-      backupCodexFiles()
-
-      // Assert
-      expect(filterFunction).toBeDefined()
-      if (filterFunction) {
-        expect(filterFunction('/home/user/.codex/config.toml')).toBe(true)
-        expect(filterFunction('/home/user/.codex/backup/old-backup')).toBe(false)
-        expect(filterFunction('/home/user/.codex/some/backup/nested')).toBe(false)
-      }
-    })
-
     it('should handle copy errors gracefully', async () => {
-      // Arrange
       mockExists.mockReturnValue(true)
-      mockCopyDir.mockImplementation(() => {
+      mockCopyFile.mockImplementation(() => {
         throw new Error('Copy failed')
       })
 
-      // Act & Assert
       const { backupCodexFiles } = await import('../../../../src/utils/code-tools/codex')
-      expect(() => backupCodexFiles()).toThrow('Copy failed')
+      const result = backupCodexFiles()
+
+      expect(result).toBeNull()
     })
   })
 

--- a/tests/unit/utils/code-tools/codex-complete-backup.test.ts
+++ b/tests/unit/utils/code-tools/codex-complete-backup.test.ts
@@ -1,9 +1,11 @@
 import { join } from 'pathe'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CODEX_AGENTS_FILE, CODEX_AUTH_FILE, CODEX_CONFIG_FILE, CODEX_DIR, CODEX_PROMPTS_DIR } from '../../../../src/constants'
 
 // Mock all external dependencies
 vi.mock('../../../../src/utils/fs-operations', () => ({
   copyDir: vi.fn(),
+  copyFile: vi.fn(),
   ensureDir: vi.fn(),
   exists: vi.fn(),
 }))
@@ -19,135 +21,88 @@ const mockedDayjs = (await import('dayjs')).default
 
 const mockedExists = vi.mocked(mockedFsOps.exists)
 const mockedCopyDir = vi.mocked(mockedFsOps.copyDir)
+const mockedCopyFile = vi.mocked(mockedFsOps.copyFile)
 const mockedEnsureDir = vi.mocked(mockedFsOps.ensureDir)
 
-// Import the functions to test after mocks are set up
-const { backupCodexComplete, CODEX_DIR } = await import('../../../../src/utils/code-tools/codex')
+const { backupCodexComplete, backupCodexTargets } = await import('../../../../src/utils/code-tools/codex')
 
-describe('backupCodexComplete', () => {
+describe('backupCodexTargets', () => {
   const expectedTimestamp = '2024-01-01_12-00-00'
   const expectedBackupDir = join(CODEX_DIR, 'backup', `backup_${expectedTimestamp}`)
 
   beforeEach(() => {
     vi.clearAllMocks()
+    delete process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP
 
-    // Setup dayjs mock to return consistent timestamp
     vi.mocked(mockedDayjs).mockReturnValue({
       format: vi.fn().mockReturnValue(expectedTimestamp),
     } as any)
   })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
+  it('should backup only requested config and auth files', () => {
+    mockedExists.mockImplementation((path: string) => {
+      return path === CODEX_CONFIG_FILE || path === CODEX_AUTH_FILE
+    })
+    mockedCopyFile.mockImplementation(() => {})
+    mockedEnsureDir.mockImplementation(() => {})
+
+    const result = backupCodexTargets(['config', 'auth'])
+
+    expect(mockedCopyFile).toHaveBeenCalledWith(CODEX_CONFIG_FILE, join(expectedBackupDir, 'config.toml'))
+    expect(mockedCopyFile).toHaveBeenCalledWith(CODEX_AUTH_FILE, join(expectedBackupDir, 'auth.json'))
+    expect(mockedCopyDir).not.toHaveBeenCalled()
+    expect(result).toBe(join(expectedBackupDir, 'config.toml'))
   })
 
-  it('should backup complete codex directory with timestamp', async () => {
-    // Arrange
-    mockedExists.mockImplementation(() => true)
+  it('should backup agents and prompts directories when requested', () => {
+    mockedExists.mockImplementation((path: string) => {
+      return path === CODEX_AGENTS_FILE || path === CODEX_PROMPTS_DIR
+    })
+    mockedCopyFile.mockImplementation(() => {})
     mockedCopyDir.mockImplementation(() => {})
     mockedEnsureDir.mockImplementation(() => {})
 
-    // Act
-    const result = backupCodexComplete()
+    const result = backupCodexTargets(['agents', 'prompts'])
 
-    // Assert - Test core behavior
-    expect(mockedExists).toHaveBeenCalledWith(CODEX_DIR)
-    expect(mockedEnsureDir).toHaveBeenCalled() // createBackupDirectory calls ensureDir
-    expect(mockedCopyDir).toHaveBeenCalledWith(
-      CODEX_DIR,
-      expectedBackupDir,
-      expect.objectContaining({
-        filter: expect.any(Function),
-      }),
-    )
-    expect(result).toBe(expectedBackupDir)
+    expect(mockedCopyFile).toHaveBeenCalledWith(CODEX_AGENTS_FILE, join(expectedBackupDir, 'AGENTS.md'))
+    expect(mockedCopyDir).toHaveBeenCalledWith(CODEX_PROMPTS_DIR, join(expectedBackupDir, 'prompts'))
+    expect(result).toBe(join(expectedBackupDir, 'AGENTS.md'))
   })
 
-  it('should exclude backup directory from backup using filter', async () => {
-    // Arrange
-    mockedExists.mockImplementation(() => true)
-    mockedCopyDir.mockImplementation(() => {})
-    mockedEnsureDir.mockImplementation(() => {})
-
-    // Act
-    backupCodexComplete()
-
-    // Assert - Check filter function excludes backup paths
-    expect(mockedCopyDir).toHaveBeenCalled()
-    const copyDirCall = mockedCopyDir.mock.calls[0]
-    const options = copyDirCall[2] as any
-    const filterFunction = options.filter
-
-    // Test filter function
-    expect(filterFunction('/some/path/file.txt')).toBe(true)
-    expect(filterFunction('/some/path/backup/file.txt')).toBe(false)
-    expect(filterFunction('/home/.codex/backup/old')).toBe(false)
-    expect(filterFunction('/home/.codex/config.toml')).toBe(true)
-  })
-
-  it('should return backup path on success', async () => {
-    // Arrange
-    mockedExists.mockImplementation(() => true)
-    mockedCopyDir.mockImplementation(() => {})
-    mockedEnsureDir.mockImplementation(() => {})
-
-    // Act
-    const result = backupCodexComplete()
-
-    // Assert
-    expect(result).toBe(expectedBackupDir)
-    expect(typeof result).toBe('string')
-  })
-
-  it('should return null when codex directory not exists', async () => {
-    // Arrange
+  it('should return null when no target files exist', () => {
     mockedExists.mockImplementation(() => false)
 
-    // Act
-    const result = backupCodexComplete()
+    const result = backupCodexTargets(['config', 'auth'])
 
-    // Assert
     expect(result).toBeNull()
+    expect(mockedCopyFile).not.toHaveBeenCalled()
     expect(mockedCopyDir).not.toHaveBeenCalled()
-    expect(mockedEnsureDir).not.toHaveBeenCalled()
   })
 
-  it('should handle backup creation errors gracefully', async () => {
-    // Arrange
-    mockedExists.mockImplementation(() => true)
+  it('should reuse backup directory in skip-prompt mode', () => {
+    process.env.ZCF_CODEX_SKIP_PROMPT_SINGLE_BACKUP = 'true'
+    mockedExists.mockImplementation((path: string) => path === CODEX_CONFIG_FILE || path === CODEX_AUTH_FILE)
+    mockedCopyFile.mockImplementation(() => {})
     mockedEnsureDir.mockImplementation(() => {})
-    mockedCopyDir.mockImplementation(() => {
-      throw new Error('Permission denied')
-    })
 
-    // Act & Assert - Should throw the error since backupCodexFiles doesn't catch it
-    expect(() => backupCodexComplete()).toThrow('Permission denied')
+    backupCodexTargets(['config'])
+    backupCodexTargets(['auth'])
+
+    expect(mockedEnsureDir).toHaveBeenCalledTimes(1)
+    expect(mockedCopyFile).toHaveBeenCalledTimes(2)
   })
 
-  it('should handle directory creation errors gracefully', async () => {
-    // Arrange
+  it('backupCodexComplete should include all known codex targets', () => {
     mockedExists.mockImplementation(() => true)
-    mockedEnsureDir.mockImplementation(() => {
-      throw new Error('Disk full')
-    })
-
-    // Act & Assert - Should throw the error since backupCodexFiles doesn't catch it
-    expect(() => backupCodexComplete()).toThrow('Disk full')
-    expect(mockedCopyDir).not.toHaveBeenCalled()
-  })
-
-  it('should use correct timestamp format', async () => {
-    // Arrange
-    mockedExists.mockImplementation(() => true)
+    mockedCopyFile.mockImplementation(() => {})
     mockedCopyDir.mockImplementation(() => {})
     mockedEnsureDir.mockImplementation(() => {})
 
-    // Act
     backupCodexComplete()
 
-    // Assert - Check dayjs format call
-    expect(vi.mocked(mockedDayjs)).toHaveBeenCalled()
-    const dayjsInstance = vi.mocked(mockedDayjs).mock.results[0].value
-    expect(dayjsInstance.format).toHaveBeenCalledWith('YYYY-MM-DD_HH-mm-ss')
+    expect(mockedCopyFile).toHaveBeenCalledWith(CODEX_CONFIG_FILE, join(expectedBackupDir, 'config.toml'))
+    expect(mockedCopyFile).toHaveBeenCalledWith(CODEX_AUTH_FILE, join(expectedBackupDir, 'auth.json'))
+    expect(mockedCopyFile).toHaveBeenCalledWith(CODEX_AGENTS_FILE, join(expectedBackupDir, 'AGENTS.md'))
+    expect(mockedCopyDir).toHaveBeenCalledWith(CODEX_PROMPTS_DIR, join(expectedBackupDir, 'prompts'))
   })
 })

--- a/tests/unit/utils/code-tools/codex-configure.test.ts
+++ b/tests/unit/utils/code-tools/codex-configure.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../../src/utils/zcf-config', () => ({
 }))
 
 vi.mock('../../../../src/utils/code-tools/codex', () => ({
-  backupCodexComplete: vi.fn(),
+  backupCodexTargets: vi.fn(),
   getBackupMessage: vi.fn((path: string) => `Backup created: ${path}`),
   readCodexConfig: vi.fn(),
   runCodexWorkflowSelection: vi.fn(),
@@ -69,9 +69,9 @@ describe('codex-configure', () => {
     it('should skip MCP installation when mcpServices is false', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { updateZcfConfig } = vi.mocked(await import('../../../../src/utils/zcf-config'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
 
       const options: CodexFullInitOptions = {
@@ -86,11 +86,11 @@ describe('codex-configure', () => {
 
     it('should use provided mcpServices list in skipPrompt mode', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(null)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const options: CodexFullInitOptions = {
         skipPrompt: true,
@@ -104,11 +104,11 @@ describe('codex-configure', () => {
 
     it('should handle serena with --context already present in args', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(null)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const options: CodexFullInitOptions = {
         skipPrompt: true,
@@ -123,13 +123,13 @@ describe('codex-configure', () => {
     it('should handle Windows environment with SYSTEMROOT', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { isWindows, getSystemRoot } = vi.mocked(await import('../../../../src/utils/platform'))
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       isWindows.mockReturnValue(true)
       getSystemRoot.mockReturnValue('C:\\Windows')
       readCodexConfig.mockReturnValue(null)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const options: CodexFullInitOptions = {
         skipPrompt: true,
@@ -146,13 +146,13 @@ describe('codex-configure', () => {
     it('should handle Windows environment when getSystemRoot returns null', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { isWindows, getSystemRoot } = vi.mocked(await import('../../../../src/utils/platform'))
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       isWindows.mockReturnValue(true)
       getSystemRoot.mockReturnValue(null)
       readCodexConfig.mockReturnValue(null)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const options: CodexFullInitOptions = {
         skipPrompt: true,
@@ -169,7 +169,7 @@ describe('codex-configure', () => {
 
     it('should merge existing MCP services with new services', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       const existingConfig: CodexConfigData = {
@@ -182,7 +182,7 @@ describe('codex-configure', () => {
       }
 
       readCodexConfig.mockReturnValue(existingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const options: CodexFullInitOptions = {
         skipPrompt: true,
@@ -200,7 +200,7 @@ describe('codex-configure', () => {
     it('should handle Windows environment in finalServices mapping', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { isWindows, getSystemRoot } = vi.mocked(await import('../../../../src/utils/platform'))
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       isWindows.mockReturnValue(true)
@@ -216,7 +216,7 @@ describe('codex-configure', () => {
       }
 
       readCodexConfig.mockReturnValue(existingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const options: CodexFullInitOptions = {
         skipPrompt: true,
@@ -233,10 +233,10 @@ describe('codex-configure', () => {
     it('should return early when selectMcpServices returns undefined', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(undefined)
 
@@ -248,11 +248,11 @@ describe('codex-configure', () => {
     it('should handle empty selection in interactive mode', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
       const { updateZcfConfig } = vi.mocked(await import('../../../../src/utils/zcf-config'))
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue([])
 
@@ -266,12 +266,12 @@ describe('codex-configure', () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
       const { isWindows, getSystemRoot } = vi.mocked(await import('../../../../src/utils/platform'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       isWindows.mockReturnValue(true)
       getSystemRoot.mockReturnValue('C:\\Windows')
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
 
       const existingConfig: CodexConfigData = {
         model: null,
@@ -295,10 +295,10 @@ describe('codex-configure', () => {
     it('should handle services selection with non-API-key services', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(['context7'])
 
@@ -310,10 +310,10 @@ describe('codex-configure', () => {
     it('should handle serena service context modification in interactive mode', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(['serena'])
 
@@ -325,10 +325,10 @@ describe('codex-configure', () => {
     it('should modify existing --context value for serena in interactive mode', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(['serena'])
 
@@ -344,11 +344,11 @@ describe('codex-configure', () => {
     it('should handle API key service with prompt in interactive mode', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
       const inquirer = await import('inquirer')
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(['exa'])
       vi.mocked(inquirer.default.prompt).mockResolvedValue({ apiKey: 'test-api-key' })
@@ -361,11 +361,11 @@ describe('codex-configure', () => {
     it('should skip API key service when no key provided', async () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
       const inquirer = await import('inquirer')
 
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(['exa'])
       vi.mocked(inquirer.default.prompt).mockResolvedValue({ apiKey: '' })
@@ -382,12 +382,12 @@ describe('codex-configure', () => {
       const { configureCodexMcp } = await import('../../../../src/utils/code-tools/codex-configure')
       const { selectMcpServices } = vi.mocked(await import('../../../../src/utils/mcp-selector'))
       const { isWindows, getSystemRoot } = vi.mocked(await import('../../../../src/utils/platform'))
-      const { backupCodexComplete, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { backupCodexTargets, readCodexConfig } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const { batchUpdateCodexMcpServices } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       isWindows.mockReturnValue(true)
       getSystemRoot.mockReturnValue('C:\\Windows')
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       readCodexConfig.mockReturnValue(null)
       selectMcpServices.mockResolvedValue(['context7'])
 

--- a/tests/unit/utils/code-tools/codex-incremental-config.test.ts
+++ b/tests/unit/utils/code-tools/codex-incremental-config.test.ts
@@ -10,7 +10,7 @@ import {
 // Mock the codex module functions
 vi.mock('../../../../src/utils/code-tools/codex', () => ({
   readCodexConfig: vi.fn(),
-  backupCodexComplete: vi.fn(),
+  backupCodexTargets: vi.fn(),
   writeAuthFile: vi.fn(),
 }))
 
@@ -65,7 +65,7 @@ describe('codex-incremental-config integration', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
         writeAuthFile,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
@@ -75,7 +75,7 @@ describe('codex-incremental-config integration', () => {
 
       // Initial configuration exists
       readCodexConfig.mockReturnValue(initialConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       // Step 1: Detect management mode
       const detectionResult = detectConfigManagementMode()
@@ -141,7 +141,7 @@ describe('codex-incremental-config integration', () => {
       expect(deleteCodexProvider).toHaveBeenCalledWith('provider-2')
 
       // Verify all operations created backups
-      expect(backupCodexComplete).toHaveBeenCalledTimes(3)
+      expect(backupCodexTargets).toHaveBeenCalledTimes(3)
     })
 
     it('should detect initial mode for fresh installations', async () => {
@@ -166,7 +166,7 @@ describe('codex-incremental-config integration', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         upsertCodexProvider,
@@ -205,7 +205,7 @@ describe('codex-incremental-config integration', () => {
       }
 
       readCodexConfig.mockReturnValue(complexConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       const newProviderToAdd = {
         id: 'provider-3',
@@ -276,7 +276,7 @@ describe('codex-incremental-config integration', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         updateCodexApiFields,
@@ -310,7 +310,7 @@ describe('codex-incremental-config integration', () => {
       }
 
       readCodexConfig.mockReturnValue(multiProviderConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       // Act: Delete the current default provider
       const deleteResult = await deleteProviders(['provider-1'])

--- a/tests/unit/utils/code-tools/codex-language-selection.test.ts
+++ b/tests/unit/utils/code-tools/codex-language-selection.test.ts
@@ -355,7 +355,7 @@ model_provider = "official"
       )
       expect(updateZcfConfig).toHaveBeenCalledWith({ aiOutputLang: mockAiOutputLang })
       expect(updateZcfConfig).toHaveBeenCalledWith({ templateLang: 'zh-CN' })
-      expect(applyAiLanguageDirective).toHaveBeenCalledWith(mockAiOutputLang)
+      expect(applyAiLanguageDirective).not.toHaveBeenCalled()
 
       const agentsWriteCalls = vi.mocked(writeFile).mock.calls.filter(call => call[0]?.includes('AGENTS.md'))
       expect(agentsWriteCalls.at(-1)?.[1]).toContain('**Most Important:Always respond in Chinese-simplified**')

--- a/tests/unit/utils/code-tools/codex-provider-manager.test.ts
+++ b/tests/unit/utils/code-tools/codex-provider-manager.test.ts
@@ -10,7 +10,7 @@ import {
 // Mock the codex module functions
 vi.mock('../../../../src/utils/code-tools/codex', () => ({
   readCodexConfig: vi.fn(),
-  backupCodexComplete: vi.fn(),
+  backupCodexTargets: vi.fn(),
   writeAuthFile: vi.fn(),
 }))
 
@@ -65,7 +65,7 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
         writeAuthFile,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
@@ -73,13 +73,13 @@ describe('codex-provider-manager', () => {
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       // Act
       const result = await addProviderToExisting(mockNewProvider, 'new-api-key-value')
 
       // Assert
-      expect(backupCodexComplete).toHaveBeenCalledOnce()
+      expect(backupCodexTargets).toHaveBeenCalledOnce()
       // New implementation uses targeted upsertCodexProvider instead of writeCodexConfig
       expect(upsertCodexProvider).toHaveBeenCalledWith(mockNewProvider.id, mockNewProvider)
       expect(writeAuthFile).toHaveBeenCalledWith({
@@ -119,14 +119,14 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         upsertCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       const duplicateProvider: CodexProvider = {
         ...mockNewProvider,
@@ -147,7 +147,7 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         updateCodexApiFields,
@@ -174,7 +174,7 @@ describe('codex-provider-manager', () => {
       }
 
       readCodexConfig.mockReturnValue(configWithNullModelProvider)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       const duplicateProvider: CodexProvider = {
         ...mockNewProvider,
@@ -196,13 +196,13 @@ describe('codex-provider-manager', () => {
 
     it('should create new configuration when none exists', async () => {
       // Arrange
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         updateCodexApiFields,
         upsertCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
       readCodexConfig.mockReturnValue(null)
-      backupCodexComplete.mockReturnValue(null) // No backup needed for new config
+      backupCodexTargets.mockReturnValue(null) // No backup needed for new config
 
       // Act
       const result = await addProviderToExisting(mockNewProvider, 'api-key')
@@ -223,11 +223,11 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue(null) // Backup failed
+      backupCodexTargets.mockReturnValue(null) // Backup failed
 
       // Act
       const result = await addProviderToExisting(mockNewProvider, 'api-key')
@@ -243,14 +243,14 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         upsertCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       upsertCodexProvider.mockImplementation(() => {
         throw new Error('Write failed')
       })
@@ -269,7 +269,7 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
         writeAuthFile,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
@@ -277,7 +277,7 @@ describe('codex-provider-manager', () => {
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       const updates = {
         name: 'Updated Provider Name',
@@ -290,7 +290,7 @@ describe('codex-provider-manager', () => {
       const result = await editExistingProvider('existing-provider', updates)
 
       // Assert
-      expect(backupCodexComplete).toHaveBeenCalledOnce()
+      expect(backupCodexTargets).toHaveBeenCalledOnce()
       // New implementation uses upsertCodexProvider for targeted updates
       expect(upsertCodexProvider).toHaveBeenCalledWith('existing-provider', {
         ...mockExistingConfig.providers[0],
@@ -334,14 +334,14 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         upsertCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       const partialUpdates = {
         name: 'Partially Updated Name',
@@ -376,9 +376,9 @@ describe('codex-provider-manager', () => {
 
     it('should return error when backup fails', async () => {
       // Arrange
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue(null)
+      backupCodexTargets.mockReturnValue(null)
 
       // Act
       const result = await editExistingProvider('existing-provider', { name: 'New Name' })
@@ -394,14 +394,14 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         upsertCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       const updates = {
         model: 'gpt-5-turbo',
@@ -422,14 +422,14 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         upsertCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(mockExistingConfig)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       upsertCodexProvider.mockImplementation(() => {
         throw new Error('Write operation failed')
       })
@@ -482,20 +482,20 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         deleteCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(multiProviderConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       // Act
       const result = await deleteProviders(['provider-2', 'provider-3'])
 
       // Assert
-      expect(backupCodexComplete).toHaveBeenCalledOnce()
+      expect(backupCodexTargets).toHaveBeenCalledOnce()
       // New implementation uses deleteCodexProvider for targeted deletion
       expect(deleteCodexProvider).toHaveBeenCalledWith('provider-2')
       expect(deleteCodexProvider).toHaveBeenCalledWith('provider-3')
@@ -511,7 +511,7 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         updateCodexApiFields,
@@ -519,7 +519,7 @@ describe('codex-provider-manager', () => {
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(multiProviderConfig)
-      backupCodexComplete.mockReturnValue('/backup/path/config.toml')
+      backupCodexTargets.mockReturnValue('/backup/path/config.toml')
 
       // Act - Delete the current default provider (provider-1)
       const result = await deleteProviders(['provider-1'])
@@ -604,9 +604,9 @@ describe('codex-provider-manager', () => {
 
     it('should return error when backup fails', async () => {
       // Arrange
-      const { readCodexConfig, backupCodexComplete } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
+      const { readCodexConfig, backupCodexTargets } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       readCodexConfig.mockReturnValue(multiProviderConfig)
-      backupCodexComplete.mockReturnValue(null)
+      backupCodexTargets.mockReturnValue(null)
 
       // Act
       const result = await deleteProviders(['provider-2'])
@@ -622,14 +622,14 @@ describe('codex-provider-manager', () => {
       // Arrange
       const {
         readCodexConfig,
-        backupCodexComplete,
+        backupCodexTargets,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex'))
       const {
         deleteCodexProvider,
       } = vi.mocked(await import('../../../../src/utils/code-tools/codex-toml-updater'))
 
       readCodexConfig.mockReturnValue(multiProviderConfig)
-      backupCodexComplete.mockReturnValue('/backup/path')
+      backupCodexTargets.mockReturnValue('/backup/path')
       deleteCodexProvider.mockImplementation(() => {
         throw new Error('Delete operation failed')
       })

--- a/tests/unit/utils/code-tools/codex.test.ts
+++ b/tests/unit/utils/code-tools/codex.test.ts
@@ -355,9 +355,9 @@ describe('codex code tool utilities', () => {
 
     const codexModule = await import('../../../../src/utils/code-tools/codex')
     const writeFileMock = vi.mocked(fsOps.writeFile)
-    const copyDirMock = vi.mocked(fsOps.copyDir)
+    const copyFileMock = vi.mocked(fsOps.copyFile)
     writeFileMock.mockClear()
-    copyDirMock.mockClear()
+    copyFileMock.mockClear()
 
     // Mock promptBoolean (not used in official mode, but clear any previous mocks)
     mockedPromptBoolean.mockClear()
@@ -367,9 +367,8 @@ describe('codex code tool utilities', () => {
     // Verify that writeJsonConfig was called
     expect(jsonModule.writeJsonConfig).toHaveBeenCalled()
 
-    // Note: Backup now uses complete backup (copyDir) instead of partial backup (copyFile)
-    // This test validates the core functionality but backup verification is handled by dedicated backup tests
-    expect(copyDirMock).toHaveBeenCalled() // Verify backup functionality is called
+    // Backup should only copy files that will be modified
+    expect(copyFileMock).toHaveBeenCalled()
     const configContent = writeFileMock.mock.calls[0][1] as string
     // In official mode, model_provider should be commented but providers should be preserved
     expect(configContent).toContain('# model_provider = "packycode"')
@@ -402,15 +401,14 @@ describe('codex code tool utilities', () => {
 
     const codexModule = await import('../../../../src/utils/code-tools/codex-configure')
     const writeFileMock = vi.mocked(fsOps.writeFile)
-    const copyDirMock = vi.mocked(fsOps.copyDir)
+    const copyFileMock = vi.mocked(fsOps.copyFile)
     writeFileMock.mockClear()
-    copyDirMock.mockClear()
+    copyFileMock.mockClear()
 
     await codexModule.configureCodexMcp()
 
-    // Note: Backup now uses complete backup (copyDir) instead of partial backup (copyFile)
-    // This test validates the core functionality but backup verification is handled by dedicated backup tests
-    expect(copyDirMock).toHaveBeenCalled() // Verify backup functionality is called
+    // Backup should only copy files that will be modified
+    expect(copyFileMock).toHaveBeenCalled()
     expect(writeFileMock).toHaveBeenCalledTimes(1)
     const updated = writeFileMock.mock.calls[0][1] as string
     expect(updated).toContain('[mcp_servers.context7]')
@@ -846,9 +844,10 @@ describe('codex code tool utilities', () => {
       expect(result).toBeNull()
     })
 
-    it('backupCodexComplete should create full configuration backup', async () => {
+    it('backupCodexComplete should create targeted configuration backup', async () => {
       const fsOps = await import('../../../../src/utils/fs-operations')
       vi.mocked(fsOps.exists).mockReturnValue(true)
+      vi.mocked(fsOps.copyFile).mockImplementation(() => {})
       vi.mocked(fsOps.copyDir).mockImplementation(() => {})
       vi.mocked(fsOps.ensureDir).mockImplementation(() => {})
 
@@ -856,6 +855,7 @@ describe('codex code tool utilities', () => {
       const result = codexModule.backupCodexComplete()
 
       expect(result).toMatch(/backup.*backup_20\d{2}-/)
+      expect(fsOps.copyFile).toHaveBeenCalled()
       expect(fsOps.copyDir).toHaveBeenCalled()
     })
 
@@ -1963,8 +1963,8 @@ model_provider = ""
         const result = await codexModule.switchToProvider('test-provider')
 
         expect(result).toBe(true)
-        // Should create backup
-        expect(fsOps.copyDir).toHaveBeenCalled()
+        // Should create targeted backup for config/auth
+        expect(fsOps.copyFile).toHaveBeenCalled()
         // Should write updated config
         expect(fsOps.writeFile).toHaveBeenCalled()
         // Should update auth file with OPENAI_API_KEY set to TEST_KEY value

--- a/tests/unit/utils/prompts.test.ts
+++ b/tests/unit/utils/prompts.test.ts
@@ -708,11 +708,20 @@ describe('prompts utilities', () => {
       expect(inquirer.prompt).toHaveBeenCalled()
     })
 
-    it('should exit when cancelled', async () => {
+    it('should return empty string when user skips selection', async () => {
+      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'skip' })
+
+      const result = await resolveSystemPromptStyle(availablePrompts, undefined, null)
+
+      expect(result).toBe('')
+    })
+
+    it('should return empty string when selection is cancelled', async () => {
       vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: undefined })
 
-      await expect(resolveSystemPromptStyle(availablePrompts, undefined, null)).rejects.toThrow('process.exit called')
-      expect(exitSpy).toHaveBeenCalledWith(0)
+      const result = await resolveSystemPromptStyle(availablePrompts, undefined, null)
+
+      expect(result).toBe('')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Codex 工作流导入不再调用 `applyAiLanguageDirective`，避免整文件覆写 `~/.claude/CLAUDE.md`；语言指令仅通过 `ensureCodexAgentsLanguageDirective` 写入 Codex 侧 `AGENTS.md`
- 交互式流程补齐跳过选项：API 配置（`api:skipApi`）、系统提示词选择（`common:skip`）；工作流多选空选本身即跳过
- 新增 `backupCodexTargets()`，将原先 `backupCodexComplete()` 全目录备份改为仅备份将被修改的目标文件（config.toml / auth.json / AGENTS.md / prompts）

## Test plan

- [x] `pnpm install`
- [x] `vitest run tests/unit/utils/code-tools/ tests/unit/utils/prompts.test.ts`（458 passed）
- [ ] 人工验证：Codex 完整初始化后 `~/.claude/CLAUDE.md` 内容不变
- [ ] 人工验证：各步骤选择「跳过」时不替换已有文件

请人工合并 PR。