### PR TITLE
fix(codex): stop Codex init from overwriting Claude CLAUDE.md (zcf#398)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -469,9 +469,11 @@ export async function init(options: InitOptions = {}): Promise<void> {
       const resolvedAiOutputLang = await runCodexFullInit({
         aiOutputLang: options.aiOutputLang,
         skipPrompt: options.skipPrompt,
+        configAction: options.configAction,
         apiMode,
         customApiConfig,
         workflows: options.workflows === false ? false : selectedWorkflows,
+        systemPromptStyle: options.outputStyles === false ? false : undefined,
       })
       updateZcfConfig({
         version,

--- a/src/i18n/locales/en/codex.json
+++ b/src/i18n/locales/en/codex.json
@@ -8,6 +8,7 @@
   "unknownInstallMethod": "⚠️ Unable to detect Codex installation method",
   "fallingBackToNpm": "Falling back to npm update method",
   "workflowInstall": "✔ Codex workflow templates installed",
+  "continueConfig": "Continue configuration",
   "backupSuccess": "✔ Backup created at {{path}}",
   "apiModePrompt": "Select API configuration mode",
   "apiModeOfficial": "Use official login (no API configuration)",

--- a/src/i18n/locales/zh-CN/codex.json
+++ b/src/i18n/locales/zh-CN/codex.json
@@ -8,6 +8,7 @@
   "unknownInstallMethod": "⚠️ 无法检测 Codex 安装方式",
   "fallingBackToNpm": "回退到 npm 更新方式",
   "workflowInstall": "✔ 已安装 Codex 工作流模板",
+  "continueConfig": "继续配置",
   "backupSuccess": "✔ 已创建备份 {{path}}",
   "apiModePrompt": "请选择 API 配置模式",
   "apiModeOfficial": "使用官方登录（不配置 API）",

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -1102,9 +1102,11 @@ export interface CodexWorkflowLanguageOptions {
   skipPrompt?: boolean
   configAction?: 'new' | 'backup' | 'merge' | 'docs-only' | 'skip'
   systemPromptStyle?: string | false
+  /** When true, skip AI language resolution (caller already resolved and saved) */
+  skipLanguageSelection?: boolean
 }
 
-type CodexConfigAction = NonNullable<CodexWorkflowLanguageOptions['configAction']>
+type CodexConfigAction = 'continue' | 'skip'
 
 function hasExistingCodexConfig(): boolean {
   return exists(CODEX_AGENTS_FILE) || exists(CODEX_CONFIG_FILE)
@@ -1129,9 +1131,7 @@ async function resolveCodexConfigAction(options?: CodexFullInitOptions): Promise
     name: 'action',
     message: i18n.t('configuration:existingConfig'),
     choices: addNumbersToChoices([
-      { name: i18n.t('configuration:backupAndOverwrite'), value: 'backup' },
-      { name: i18n.t('configuration:updateDocsOnly'), value: 'docs-only' },
-      { name: i18n.t('configuration:mergeConfig'), value: 'merge' },
+      { name: i18n.t('codex:continueConfig'), value: 'continue' },
       { name: i18n.t('common:skip'), value: 'skip' },
     ]),
   })
@@ -1156,21 +1156,20 @@ export async function runCodexWorkflowImportWithLanguageSelection(
 
   // Step 1: Select AI output language (uses global config memory)
   const zcfConfig = readZcfConfig()
-  const { aiOutputLang: commandLineOption, skipPrompt = false } = options ?? {}
+  const { aiOutputLang: commandLineOption, skipPrompt = false, skipLanguageSelection = false } = options ?? {}
 
-  const aiOutputLang = await resolveAiOutputLanguage(
-    i18n.language as SupportedLang,
-    commandLineOption,
-    zcfConfig,
-    skipPrompt,
-  )
+  const aiOutputLang = skipLanguageSelection
+    ? (commandLineOption ?? zcfConfig?.aiOutputLang ?? 'en')
+    : await resolveAiOutputLanguage(
+        i18n.language as SupportedLang,
+        commandLineOption,
+        zcfConfig,
+        skipPrompt,
+      )
 
   // Step 2: Save AI output language to global config (ZCF metadata only — never touch ~/.claude/CLAUDE.md)
-  updateZcfConfig({ aiOutputLang })
-
-  const configAction = await resolveCodexConfigAction(options)
-  if (configAction === 'skip')
-    return aiOutputLang
+  if (!skipLanguageSelection)
+    updateZcfConfig({ aiOutputLang })
 
   // Step 3: System prompt + workflow selection (Codex-side files only)
   await runCodexSystemPromptSelection(options)
@@ -1744,7 +1743,25 @@ export async function runCodexFullInit(
   ensureI18nInitialized()
 
   await installCodexCli(options?.skipPrompt || false)
-  const aiOutputLang = await runCodexWorkflowImportWithLanguageSelection(options)
+
+  const zcfConfig = readZcfConfig()
+  const aiOutputLang = await resolveAiOutputLanguage(
+    i18n.language as SupportedLang,
+    options?.aiOutputLang,
+    zcfConfig,
+    options?.skipPrompt ?? false,
+  )
+  updateZcfConfig({ aiOutputLang })
+
+  const configAction = await resolveCodexConfigAction(options)
+  if (configAction === 'skip')
+    return aiOutputLang
+
+  await runCodexWorkflowImportWithLanguageSelection({
+    ...options,
+    aiOutputLang,
+    skipLanguageSelection: true,
+  })
   await configureCodexApi(options)
   await configureCodexMcp(options)
 

--- a/src/utils/code-tools/codex.ts
+++ b/src/utils/code-tools/codex.ts
@@ -12,7 +12,6 @@ import { x } from 'tinyexec'
 // Removed MCP config imports; MCP configuration moved to codex-configure.ts
 import { AI_OUTPUT_LANGUAGES, CODEX_AGENTS_FILE, CODEX_AUTH_FILE, CODEX_CONFIG_FILE, CODEX_DIR, CODEX_PROMPTS_DIR, SUPPORTED_LANGS, ZCF_CONFIG_FILE } from '../../constants'
 import { ensureI18nInitialized, format, i18n } from '../../i18n'
-import { applyAiLanguageDirective } from '../config'
 import { copyDir, copyFile, ensureDir, exists, readFile, writeFile } from '../fs-operations'
 import { readJsonConfig, writeJsonConfig } from '../json-config'
 import { normalizeTomlPath, wrapCommandWithSudo } from '../platform'
@@ -1101,6 +1100,53 @@ export async function runCodexWorkflowImport(): Promise<void> {
 export interface CodexWorkflowLanguageOptions {
   aiOutputLang?: AiOutputLanguage | string
   skipPrompt?: boolean
+  configAction?: 'new' | 'backup' | 'merge' | 'docs-only' | 'skip'
+  systemPromptStyle?: string | false
+}
+
+type CodexConfigAction = NonNullable<CodexWorkflowLanguageOptions['configAction']>
+
+function hasExistingCodexConfig(): boolean {
+  return exists(CODEX_AGENTS_FILE) || exists(CODEX_CONFIG_FILE)
+}
+
+async function resolveCodexConfigAction(options?: CodexFullInitOptions): Promise<'proceed' | 'skip'> {
+  const { skipPrompt = false, configAction } = options ?? {}
+
+  if (!hasExistingCodexConfig())
+    return 'proceed'
+
+  if (skipPrompt) {
+    if (configAction === 'skip') {
+      console.log(ansis.yellow(i18n.t('common:skip')))
+      return 'skip'
+    }
+    return 'proceed'
+  }
+
+  const { action } = await inquirer.prompt<{ action: CodexConfigAction }>({
+    type: 'list',
+    name: 'action',
+    message: i18n.t('configuration:existingConfig'),
+    choices: addNumbersToChoices([
+      { name: i18n.t('configuration:backupAndOverwrite'), value: 'backup' },
+      { name: i18n.t('configuration:updateDocsOnly'), value: 'docs-only' },
+      { name: i18n.t('configuration:mergeConfig'), value: 'merge' },
+      { name: i18n.t('common:skip'), value: 'skip' },
+    ]),
+  })
+
+  if (!action) {
+    console.log(ansis.yellow(i18n.t('common:cancelled')))
+    return 'skip'
+  }
+
+  if (action === 'skip') {
+    console.log(ansis.yellow(i18n.t('common:skip')))
+    return 'skip'
+  }
+
+  return 'proceed'
 }
 
 export async function runCodexWorkflowImportWithLanguageSelection(
@@ -1119,12 +1165,15 @@ export async function runCodexWorkflowImportWithLanguageSelection(
     skipPrompt,
   )
 
-  // Step 2: Save AI output language to global config
+  // Step 2: Save AI output language to global config (ZCF metadata only — never touch ~/.claude/CLAUDE.md)
   updateZcfConfig({ aiOutputLang })
-  applyAiLanguageDirective(aiOutputLang)
 
-  // Step 3: Continue with original workflow (system prompt + workflow selection)
-  await runCodexSystemPromptSelection(skipPrompt)
+  const configAction = await resolveCodexConfigAction(options)
+  if (configAction === 'skip')
+    return aiOutputLang
+
+  // Step 3: System prompt + workflow selection (Codex-side files only)
+  await runCodexSystemPromptSelection(options)
   ensureCodexAgentsLanguageDirective(aiOutputLang)
   await runCodexWorkflowSelection(options)
   console.log(ansis.green(i18n.t('codex:workflowInstall')))
@@ -1132,7 +1181,11 @@ export async function runCodexWorkflowImportWithLanguageSelection(
   return aiOutputLang
 }
 
-export async function runCodexSystemPromptSelection(skipPrompt = false): Promise<void> {
+export async function runCodexSystemPromptSelection(options?: Pick<CodexFullInitOptions, 'skipPrompt' | 'systemPromptStyle'>): Promise<void> {
+  const { skipPrompt = false, systemPromptStyle } = options ?? {}
+
+  if (systemPromptStyle === false)
+    return
   ensureI18nInitialized()
   const rootDir = getRootDir()
 
@@ -1189,11 +1242,12 @@ export async function runCodexSystemPromptSelection(skipPrompt = false): Promise
 
   // Use the new intelligent detection function
   const { resolveSystemPromptStyle } = await import('../prompts')
+  const systemPromptOption = typeof systemPromptStyle === 'string' ? systemPromptStyle : undefined
   const systemPrompt = await resolveSystemPromptStyle(
     availablePrompts,
-    undefined, // No command line option for this function
+    systemPromptOption,
     tomlConfig,
-    skipPrompt, // Pass skipPrompt flag
+    skipPrompt,
   )
 
   if (!systemPrompt)
@@ -1391,6 +1445,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
   const modeChoices = [
     { name: i18n.t('codex:apiModeOfficial'), value: 'official' },
     { name: i18n.t('codex:apiModeCustom'), value: 'custom' },
+    { name: i18n.t('common:skip'), value: 'skip' },
   ]
 
   // Add switch option if providers exist
@@ -1398,7 +1453,7 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
     modeChoices.push({ name: i18n.t('codex:configSwitchMode'), value: 'switch' })
   }
 
-  const { mode } = await inquirer.prompt<{ mode: 'official' | 'custom' | 'switch' }>([{
+  const { mode } = await inquirer.prompt<{ mode: 'official' | 'custom' | 'switch' | 'skip' }>([{
     type: 'list',
     name: 'mode',
     message: i18n.t('codex:apiModePrompt'),
@@ -1408,6 +1463,11 @@ export async function configureCodexApi(options?: CodexFullInitOptions): Promise
 
   if (!mode) {
     console.log(ansis.yellow(i18n.t('common:cancelled')))
+    return
+  }
+
+  if (mode === 'skip') {
+    console.log(ansis.yellow(i18n.t('common:skip')))
     return
   }
 

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -284,7 +284,7 @@ export async function resolveSystemPromptStyle(
   commandLineOption?: string,
   savedConfig?: ZcfTomlConfig | null,
   skipPrompt?: boolean,
-): Promise<string> {
+): Promise<string | null> {
   ensureI18nInitialized()
 
   // Priority 1: Command line option
@@ -313,7 +313,7 @@ export async function resolveSystemPromptStyle(
 
       if (!shouldModify) {
         console.log(ansis.gray(`✔ ${i18n.t('language:currentSystemPromptFound')}: ${currentStyle.name}`))
-        return currentStyleId
+        return null
       }
     }
   }

--- a/tests/unit/commands/init.test.ts
+++ b/tests/unit/commands/init.test.ts
@@ -532,9 +532,11 @@ describe('init command', () => {
         expect(runCodexFullInitSpy).toHaveBeenCalledWith({
           aiOutputLang: 'en',
           skipPrompt: true,
+          configAction: 'backup',
           apiMode: 'skip',
           customApiConfig: undefined,
           workflows: ['commonTools', 'sixStepsWorkflow', 'featPlanUx', 'gitWorkflow', 'bmadWorkflow'],
+          systemPromptStyle: undefined,
         })
       })
 
@@ -564,9 +566,11 @@ describe('init command', () => {
         expect(runCodexFullInitSpy).toHaveBeenCalledWith({
           aiOutputLang: undefined,
           skipPrompt: true,
+          configAction: 'backup',
           apiMode: 'skip',
           customApiConfig: undefined,
           workflows: ['commonTools', 'sixStepsWorkflow', 'featPlanUx', 'gitWorkflow', 'bmadWorkflow'],
+          systemPromptStyle: undefined,
         })
         // Should not call resolveTemplateLanguage for codex when skipPrompt is true
         expect(testMocks.resolveTemplateLanguage).not.toHaveBeenCalled()
@@ -637,9 +641,11 @@ describe('init command', () => {
         expect(runCodexFullInitSpy).toHaveBeenCalledWith({
           aiOutputLang: 'japanese',
           skipPrompt: true,
+          configAction: 'backup',
           apiMode: 'skip',
           customApiConfig: undefined,
           workflows: ['commonTools', 'sixStepsWorkflow', 'featPlanUx', 'gitWorkflow', 'bmadWorkflow'],
+          systemPromptStyle: undefined,
         })
 
         expect(runCodexFullInitSpy).toHaveBeenCalled()

--- a/tests/unit/utils/code-tools/codex-language-selection.test.ts
+++ b/tests/unit/utils/code-tools/codex-language-selection.test.ts
@@ -75,6 +75,7 @@ vi.mock('../../../../src/utils/platform', () => ({
   isWindows: vi.fn(() => false),
   getSystemRoot: vi.fn(() => 'C:\\Windows'),
   normalizeTomlPath: vi.fn((str: string) => str),
+  wrapCommandWithSudo: vi.fn((command: string, args: string[]) => ({ command, args, usedSudo: false })),
 }))
 
 // Mock prompt helpers
@@ -341,9 +342,7 @@ model_provider = "official"
       vi.mocked(resolveAiOutputLanguage).mockResolvedValue(mockAiOutputLang)
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
-      vi.mocked(inquirer.prompt)
-        .mockResolvedValueOnce({ action: 'backup' })
-        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
+      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       // Act
       await runCodexWorkflowImportWithLanguageSelection()
@@ -377,9 +376,7 @@ model_provider = "official"
       vi.mocked(resolveAiOutputLanguage).mockResolvedValue('en') // Should return saved config
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
-      vi.mocked(inquirer.prompt)
-        .mockResolvedValueOnce({ action: 'backup' })
-        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
+      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       // Act
       await runCodexWorkflowImportWithLanguageSelection()
@@ -438,9 +435,7 @@ model_provider = "official"
       vi.mocked(resolveTemplateLanguage).mockResolvedValue('en')
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
-      vi.mocked(inquirer.prompt)
-        .mockResolvedValueOnce({ action: 'backup' })
-        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
+      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       await runCodexWorkflowImportWithLanguageSelection()
 
@@ -460,9 +455,7 @@ model_provider = "official"
       vi.mocked(resolveTemplateLanguage).mockResolvedValue('zh-CN')
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
-      vi.mocked(inquirer.prompt)
-        .mockResolvedValueOnce({ action: 'backup' })
-        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
+      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       await runCodexWorkflowImportWithLanguageSelection()
 
@@ -505,7 +498,7 @@ model_provider = "official"
       expect(applyAiLanguageDirective).not.toHaveBeenCalled()
     })
 
-    it('should skip workflow import when configAction is skip in skip-prompt mode', async () => {
+    it('should skip full init when configAction is skip in skip-prompt mode', async () => {
       const mockZcfConfig = {
         preferredLang: 'zh-CN' as const,
         version: '2.12.13',
@@ -517,13 +510,16 @@ model_provider = "official"
       vi.mocked(resolveAiOutputLanguage).mockResolvedValue('zh-CN')
       vi.mocked(exists).mockImplementation((path: string) => path.includes('AGENTS.md') || path.includes('config.toml'))
 
-      await runCodexWorkflowImportWithLanguageSelection({
+      const codexModule = await import('../../../../src/utils/code-tools/codex')
+      const result = await codexModule.runCodexFullInit({
         skipPrompt: true,
         configAction: 'skip',
       })
 
-      expect(applyAiLanguageDirective).not.toHaveBeenCalled()
+      expect(result).toBe('zh-CN')
       expect(resolveSystemPromptStyle).not.toHaveBeenCalled()
+      expect(selectAndInstallWorkflows).not.toHaveBeenCalled()
+      expect(applyAiLanguageDirective).not.toHaveBeenCalled()
       expect(inquirer.prompt).not.toHaveBeenCalled()
     })
   })

--- a/tests/unit/utils/code-tools/codex-language-selection.test.ts
+++ b/tests/unit/utils/code-tools/codex-language-selection.test.ts
@@ -76,6 +76,7 @@ vi.mock('../../../../src/utils/platform', () => ({
   getSystemRoot: vi.fn(() => 'C:\\Windows'),
   normalizeTomlPath: vi.fn((str: string) => str),
   wrapCommandWithSudo: vi.fn((command: string, args: string[]) => ({ command, args, usedSudo: false })),
+  commandExists: vi.fn(async () => true),
 }))
 
 // Mock prompt helpers

--- a/tests/unit/utils/code-tools/codex-language-selection.test.ts
+++ b/tests/unit/utils/code-tools/codex-language-selection.test.ts
@@ -341,7 +341,9 @@ model_provider = "official"
       vi.mocked(resolveAiOutputLanguage).mockResolvedValue(mockAiOutputLang)
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
-      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
+      vi.mocked(inquirer.prompt)
+        .mockResolvedValueOnce({ action: 'backup' })
+        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       // Act
       await runCodexWorkflowImportWithLanguageSelection()
@@ -355,7 +357,7 @@ model_provider = "official"
       )
       expect(updateZcfConfig).toHaveBeenCalledWith({ aiOutputLang: mockAiOutputLang })
       expect(updateZcfConfig).toHaveBeenCalledWith({ templateLang: 'zh-CN' })
-      expect(applyAiLanguageDirective).toHaveBeenCalledWith(mockAiOutputLang)
+      expect(applyAiLanguageDirective).not.toHaveBeenCalled()
 
       const agentsWriteCalls = vi.mocked(writeFile).mock.calls.filter(call => call[0]?.includes('AGENTS.md'))
       expect(agentsWriteCalls.at(-1)?.[1]).toContain('**Most Important:Always respond in Chinese-simplified**')
@@ -375,7 +377,9 @@ model_provider = "official"
       vi.mocked(resolveAiOutputLanguage).mockResolvedValue('en') // Should return saved config
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
-      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
+      vi.mocked(inquirer.prompt)
+        .mockResolvedValueOnce({ action: 'backup' })
+        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       // Act
       await runCodexWorkflowImportWithLanguageSelection()
@@ -434,6 +438,9 @@ model_provider = "official"
       vi.mocked(resolveTemplateLanguage).mockResolvedValue('en')
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
+      vi.mocked(inquirer.prompt)
+        .mockResolvedValueOnce({ action: 'backup' })
+        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       await runCodexWorkflowImportWithLanguageSelection()
 
@@ -453,6 +460,9 @@ model_provider = "official"
       vi.mocked(resolveTemplateLanguage).mockResolvedValue('zh-CN')
       vi.mocked(exists).mockReturnValue(true)
       vi.mocked(readFile).mockReturnValue('# System prompt content')
+      vi.mocked(inquirer.prompt)
+        .mockResolvedValueOnce({ action: 'backup' })
+        .mockResolvedValue({ systemPrompt: 'engineer-professional' })
 
       await runCodexWorkflowImportWithLanguageSelection()
 
@@ -474,6 +484,47 @@ model_provider = "official"
 
       // Act & Assert
       await expect(runCodexWorkflowImportWithLanguageSelection()).rejects.toThrow('Language selection failed')
+    })
+
+    it('should not call applyAiLanguageDirective during Codex workflow import', async () => {
+      const mockZcfConfig = {
+        preferredLang: 'zh-CN' as const,
+        version: '2.12.13',
+        codeToolType: 'codex' as const,
+        lastUpdated: '2025-01-15',
+      }
+
+      vi.mocked(readZcfConfig).mockReturnValue(mockZcfConfig)
+      vi.mocked(resolveAiOutputLanguage).mockResolvedValue('zh-CN')
+      vi.mocked(exists).mockReturnValue(false)
+      vi.mocked(readFile).mockReturnValue('# System prompt content')
+      vi.mocked(inquirer.prompt).mockResolvedValue({ systemPrompt: 'engineer-professional' })
+
+      await runCodexWorkflowImportWithLanguageSelection({ skipPrompt: true })
+
+      expect(applyAiLanguageDirective).not.toHaveBeenCalled()
+    })
+
+    it('should skip workflow import when configAction is skip in skip-prompt mode', async () => {
+      const mockZcfConfig = {
+        preferredLang: 'zh-CN' as const,
+        version: '2.12.13',
+        codeToolType: 'codex' as const,
+        lastUpdated: '2025-01-15',
+      }
+
+      vi.mocked(readZcfConfig).mockReturnValue(mockZcfConfig)
+      vi.mocked(resolveAiOutputLanguage).mockResolvedValue('zh-CN')
+      vi.mocked(exists).mockImplementation((path: string) => path.includes('AGENTS.md') || path.includes('config.toml'))
+
+      await runCodexWorkflowImportWithLanguageSelection({
+        skipPrompt: true,
+        configAction: 'skip',
+      })
+
+      expect(applyAiLanguageDirective).not.toHaveBeenCalled()
+      expect(resolveSystemPromptStyle).not.toHaveBeenCalled()
+      expect(inquirer.prompt).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/utils/prompts.test.ts
+++ b/tests/unit/utils/prompts.test.ts
@@ -651,7 +651,7 @@ describe('prompts utilities', () => {
         },
       )
 
-      expect(result).toBe('nekomata-engineer')
+      expect(result).toBeNull()
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('language:currentSystemPromptFound'))
       expect(promptBoolean).toHaveBeenCalledWith(expect.objectContaining({
         message: expect.stringContaining('language:modifySystemPromptPrompt'),


### PR DESCRIPTION
## Summary

- 移除 Codex 工作流导入中对 `applyAiLanguageDirective()` 的调用，避免整文件覆写 `~/.claude/CLAUDE.md`；语言指令仅通过 `ensureCodexAgentsLanguageDirective()` 写入 `~/.codex/AGENTS.md`
- 对齐 Claude init 的 skip 语义：支持 `configAction: skip`、`outputStyles: skip`（系统提示词跳过），交互模式检测已有 Codex 配置时提供跳过选项
- 用户拒绝修改系统提示词时保留现有 `AGENTS.md`；交互式 API 配置新增「跳过」选项

## Test plan

- [x] `pnpm test` 全量通过（2479 tests）
- [x] 新增单测：Codex 流程不调用 `applyAiLanguageDirective`；`configAction: skip` 跳过工作流导入
- [ ] 手动验证：`zcf init -T codex` 后 `~/.claude/CLAUDE.md` 内容不变

Fixes UfoMiao/zcf#398