### PR TITLE
fix(fs): skip special files during recursive copy

### DIFF
--- a/src/utils/fs-operations.ts
+++ b/src/utils/fs-operations.ts
@@ -227,7 +227,7 @@ export function copyDir(src: string, dest: string, options: CopyDirOptions = {})
         if (targetStats.isDirectory()) {
           copyDir(srcPath, destPath, options)
         }
-        else {
+        else if (targetStats.isFile()) {
           if (!overwrite && exists(destPath)) {
             continue
           }
@@ -244,7 +244,7 @@ export function copyDir(src: string, dest: string, options: CopyDirOptions = {})
     if (stats.isDirectory()) {
       copyDir(srcPath, destPath, options)
     }
-    else {
+    else if (stats.isFile()) {
       if (!overwrite && exists(destPath)) {
         continue
       }

--- a/tests/unit/utils/fs-operations.test.ts
+++ b/tests/unit/utils/fs-operations.test.ts
@@ -211,6 +211,17 @@ describe('fs-operations utilities', () => {
       expect(copyFileSync).toHaveBeenCalledTimes(2)
     })
 
+    it('should skip special filesystem entries such as sockets', () => {
+      const socketStats = { isDirectory: () => false, isFile: () => false, isSymbolicLink: () => false, isSocket: () => true }
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(readdirSync).mockReturnValue(['ipc.sock'] as any)
+      vi.mocked(lstatSync).mockReturnValue(socketStats as any)
+
+      copyDir('/source', '/dest')
+
+      expect(copyFileSync).not.toHaveBeenCalled()
+    })
+
     it('should handle subdirectories', () => {
       const fileStats = { isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false }
       const dirStats = { isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false }


### PR DESCRIPTION
## Summary

- Skip non-regular filesystem entries, including Unix sockets, during recursive directory copies.
- Preserve existing directory, symlink, and regular-file backup behavior.
- Add a regression test for socket entries.

Closes #405

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:run --reporter=dot` (130 files, 2480 tests passed)