### PR TITLE
feat(config): add OrcaRouter as a named API provider preset

### DIFF
--- a/docs/en/advanced/api-providers.md
+++ b/docs/en/advanced/api-providers.md
@@ -17,6 +17,7 @@ ZCF currently supports the following API provider presets:
 | `aicodemirror` | AICodeMirror | Global High-Quality Line | ✅ | ✅ | `auth_token` |
 | `aicodemirror-cn` | AICodeMirror CN | China Optimized Line | ✅ | ✅ | `auth_token` |
 | `crazyrouter` | Crazyrouter | AI API aggregation gateway | ✅ | ✅ | `api_key` |
+| `orcarouter` | OrcaRouter | AI model routing gateway | ✅ | ✅ | `auth_token` |
 | `z-ai` | Z.ai | Z.ai API service | ✅ | ❌ | `auth_token` |
 | `minimax` | MiniMax | MiniMax API service | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (Moonshot) | Moonshot AI service | ✅ | ✅ | `auth_token` |
@@ -121,6 +122,33 @@ npx zcf init -s -p crazyrouter -k "your-api-key"
 
 # Codex
 npx zcf init -s -T codex -p crazyrouter -k "your-api-key"
+```
+
+### OrcaRouter
+
+**Official Link**: [OrcaRouter](https://www.orcarouter.ai)
+
+**Features**:
+- 🚀 AI model routing gateway — one API key for 150+ models (OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI, etc.)
+- 🌐 Single endpoint for both Claude Code (Anthropic-compatible) and Codex (OpenAI-compatible)
+- 🛡️ Gateway-level security controls for AI agents on the same endpoint
+- 🔄 Auto-routing to the best available upstream
+
+**Configuration Information**:
+- **Claude Code Base URL**: `https://api.orcarouter.ai`
+- **Codex Base URL**: `https://api.orcarouter.ai/v1`
+- **Authentication Method**: `auth_token` (keys start with `sk-orca-`)
+- **Codex Wire API**: `responses`
+- **Claude Code Default Models**: `anthropic/claude-sonnet-5` (primary), `anthropic/claude-haiku-4.5` (fast)
+- **Codex Default Model**: `openai/gpt-5.5`
+
+**Usage Example**:
+```bash
+# Claude Code
+npx zcf init -s -p orcarouter -k "sk-orca-xxx"
+
+# Codex
+npx zcf init -s -T codex -p orcarouter -k "sk-orca-xxx"
 ```
 
 ### Z.ai

--- a/docs/ja-JP/advanced/api-providers.md
+++ b/docs/ja-JP/advanced/api-providers.md
@@ -17,6 +17,7 @@ ZCFは現在、以下のAPIプロバイダープリセットをサポートし�
 | `aicodemirror` | AICodeMirror | グローバル高品質回線 | ✅ | ✅ | `auth_token` |
 | `aicodemirror-cn` | AICodeMirror CN | 中国最適化回線 | ✅ | ✅ | `auth_token` |
 | `crazyrouter` | Crazyrouter | AI API 集約ゲートウェイ | ✅ | ✅ | `api_key` |
+| `orcarouter` | OrcaRouter | AI モデルルーティングゲートウェイ | ✅ | ✅ | `auth_token` |
 | `z-ai` | Z.ai | Z.ai API サービス | ✅ | ❌ | `auth_token` |
 | `minimax` | MiniMax | MiniMax APIサービス | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (月の暗面) | Moonshot AIサービス | ✅ | ✅ | `auth_token` |
@@ -121,6 +122,33 @@ npx zcf init -s -p crazyrouter -k "your-api-key"
 
 # Codex
 npx zcf init -s -T codex -p crazyrouter -k "your-api-key"
+```
+
+### OrcaRouter
+
+**公式リンク**: [OrcaRouter](https://www.orcarouter.ai)
+
+**特徴**:
+- 🚀 AI モデルルーティングゲートウェイ — 1つの API キーで 150+ モデル（OpenAI、Anthropic、Google、DeepSeek、Qwen、MiniMax、xAI など）
+- 🌐 単一エンドポイントで Claude Code（Anthropic 互換）と Codex（OpenAI 互換）の両方をサポート
+- 🛡️ 同じエンドポイントで AI エージェント向けゲートウェイレベルのセキュリティ制御
+- 🔄 最適な上流モデルへ自動ルーティング
+
+**設定情報**:
+- **Claude Code Base URL**: `https://api.orcarouter.ai`
+- **Codex Base URL**: `https://api.orcarouter.ai/v1`
+- **認証方式**: `auth_token`（キーは `sk-orca-` で始まる）
+- **Codex Wire API**: `responses`
+- **Claude Code デフォルトモデル**: `anthropic/claude-sonnet-5`（プライマリ）、`anthropic/claude-haiku-4.5`（高速）
+- **Codex デフォルトモデル**: `openai/gpt-5.5`
+
+**使用例**:
+```bash
+# Claude Code
+npx zcf init -s -p orcarouter -k "sk-orca-xxx"
+
+# Codex
+npx zcf init -s -T codex -p orcarouter -k "sk-orca-xxx"
 ```
 
 ### Z.ai

--- a/docs/zh-CN/advanced/api-providers.md
+++ b/docs/zh-CN/advanced/api-providers.md
@@ -17,6 +17,7 @@ ZCF 目前支持以下 API 提供商预设：
 | `aicodemirror` | AICodeMirror | 全球高保线路 | ✅ | ✅ | `auth_token` |
 | `aicodemirror-cn` | AICodeMirror CN | 国内优化线路 | ✅ | ✅ | `auth_token` |
 | `crazyrouter` | Crazyrouter | AI API 聚合网关 | ✅ | ✅ | `api_key` |
+| `orcarouter` | OrcaRouter | AI 模型路由网关 | ✅ | ✅ | `auth_token` |
 | `glm-cn` | GLM (智谱AI) | 智谱 AI 服务 | ✅ | ❌ | `auth_token` |
 | `minimax` | MiniMax | MiniMax API 服务 | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (月之暗面) | Moonshot AI 服务 | ✅ | ✅ | `auth_token` |
@@ -121,6 +122,33 @@ npx zcf init -s -p crazyrouter -k "your-api-key"
 
 # Codex
 npx zcf init -s -T codex -p crazyrouter -k "your-api-key"
+```
+
+### OrcaRouter
+
+**官方链接**：[OrcaRouter](https://www.orcarouter.ai)
+
+**特点**：
+- 🚀 AI 模型路由网关 —— 一个 Key 调用 150+ 模型（OpenAI、Anthropic、Google、DeepSeek、Qwen、MiniMax、xAI 等）
+- 🌐 单一端点同时支持 Claude Code（Anthropic 兼容）与 Codex（OpenAI 兼容）
+- 🛡️ 同一端点为 AI agent 提供网关级安全控制
+- 🔄 自动路由到最佳上游
+
+**配置信息**：
+- **Claude Code Base URL**: `https://api.orcarouter.ai`
+- **Codex Base URL**: `https://api.orcarouter.ai/v1`
+- **认证方式**: `auth_token`（Key 以 `sk-orca-` 开头）
+- **Codex Wire API**: `responses`
+- **Claude Code 默认模型**: `anthropic/claude-sonnet-5`（主模型）、`anthropic/claude-haiku-4.5`（快速）
+- **Codex 默认模型**: `openai/gpt-5.5`
+
+**使用示例**：
+```bash
+# Claude Code
+npx zcf init -s -p orcarouter -k "sk-orca-xxx"
+
+# Codex
+npx zcf init -s -T codex -p orcarouter -k "sk-orca-xxx"
 ```
 
 ### GLM (智谱AI)

--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -161,6 +161,23 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
   },
 
   {
+    id: 'orcarouter',
+    name: 'OrcaRouter',
+    supportedCodeTools: ['claude-code', 'codex'],
+    claudeCode: {
+      baseUrl: 'https://api.orcarouter.ai',
+      authType: 'auth_token',
+      defaultModels: ['anthropic/claude-sonnet-5', 'anthropic/claude-haiku-4.5', 'anthropic/claude-sonnet-5', 'anthropic/claude-opus-5'],
+    },
+    codex: {
+      baseUrl: 'https://api.orcarouter.ai/v1',
+      wireApi: 'responses',
+      defaultModel: 'openai/gpt-5.5',
+    },
+    description: 'OrcaRouter AI model routing gateway',
+  },
+
+  {
     id: 'aihub',
     name: 'AIHub',
     supportedCodeTools: ['claude-code', 'codex'],

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -94,6 +94,26 @@ describe('aPI Provider Configuration', () => {
       expect(provider!.codex?.defaultModel).toBe('MiniMax-M3')
     })
 
+    it('orcarouter provider should have correct configuration', () => {
+      const provider = API_PROVIDER_PRESETS.find(p => p.id === 'orcarouter')
+      expect(provider).toBeDefined()
+      expect(provider!.name).toBe('OrcaRouter')
+      expect(provider!.supportedCodeTools).toContain('claude-code')
+      expect(provider!.supportedCodeTools).toContain('codex')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.orcarouter.ai')
+      expect(provider!.claudeCode?.authType).toBe('auth_token')
+      // Order matters: [primary, haiku, sonnet, opus] — Anthropic-namespaced models
+      expect(provider!.claudeCode?.defaultModels).toEqual([
+        'anthropic/claude-sonnet-5',
+        'anthropic/claude-haiku-4.5',
+        'anthropic/claude-sonnet-5',
+        'anthropic/claude-opus-5',
+      ])
+      expect(provider!.codex?.baseUrl).toBe('https://api.orcarouter.ai/v1')
+      expect(provider!.codex?.wireApi).toBe('responses')
+      expect(provider!.codex?.defaultModel).toBe('openai/gpt-5.5')
+    })
+
     it('bailian-coding provider should use lowercase glm-5 default model', () => {
       const provider = API_PROVIDER_PRESETS.find(p => p.id === 'bailian-coding')
       expect(provider).toBeDefined()


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a named API provider preset in ZCF, registered the same way the existing gateway providers (`crazyrouter`, `302ai`, etc.) are wired — so the provider picker, `-p orcarouter` init flow, and docs stay consistent.

OrcaRouter is an OpenAI-compatible model routing gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What this changes

- **`src/config/api-providers.ts`** — new `orcarouter` preset:
  - Claude Code: base URL `https://api.orcarouter.ai`, auth `auth_token`, default models `anthropic/claude-sonnet-5` / `anthropic/claude-haiku-4.5` / `anthropic/claude-opus-5` (Anthropic-namespaced).
  - Codex: base URL `https://api.orcarouter.ai/v1`, wire API `responses`, default model `openai/gpt-5.5`.
- **`tests/unit/config/api-providers.test.ts`** — structural test for the new preset (mirrors the existing per-provider tests).
- **Docs** — OrcaRouter row + detail section in `docs/en`, `docs/zh-CN`, and `docs/ja-JP` `api-providers.md`.

### Why a named preset rather than the custom/OpenAI-compatible path

ZCF's `custom` provider already covers arbitrary OpenAI-compatible endpoints. A named `orcarouter` preset makes OrcaRouter a first-class option: correct base URLs, auth method, and default models are pre-filled, exactly like the other named gateways in the registry.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests pass
- [x] Coverage maintained

Verification:
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm build` — pass
- `pnpm vitest run` — 130 files / 2481 tests pass
- Live (L3) with a real key: `POST /v1/responses` with `openai/gpt-5.5` → HTTP 200; `POST /v1/messages` with `anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4.5`, `anthropic/claude-opus-5` → HTTP 200 (both `x-api-key` and `Authorization: Bearer`).

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

I'm an engineer on the OrcaRouter team.
