### PR TITLE
feat(config): add MiniMax China preset

### DIFF
--- a/docs/en/advanced/api-providers.md
+++ b/docs/en/advanced/api-providers.md
@@ -19,6 +19,7 @@ ZCF currently supports the following API provider presets:
 | `crazyrouter` | Crazyrouter | AI API aggregation gateway | ✅ | ✅ | `api_key` |
 | `z-ai` | Z.ai | Z.ai API service | ✅ | ❌ | `auth_token` |
 | `minimax` | MiniMax | MiniMax API service | ✅ | ✅ | `auth_token` |
+| `minimax-cn` | MiniMax CN | MiniMax China API service | ✅ | ✅ | `auth_token` |
 | `kimi` | Kimi (Moonshot) | Moonshot AI service | ✅ | ✅ | `auth_token` |
 | `custom` | Custom | Custom API endpoint | ✅ | ✅ | Must specify |
 
@@ -172,12 +173,10 @@ npx zcf init -s -p minimax -k "your-auth-token"
 npx zcf init -s -T codex -p minimax -k "your-auth-token"
 
 # Claude Code with the China endpoint
-npx zcf init -s -p custom -t auth_token -k "your-auth-token" \
-  -u "https://api.minimaxi.com/anthropic" -M "MiniMax-M3"
+npx zcf init -s -p minimax-cn -k "your-auth-token"
 
 # Codex with the China endpoint
-npx zcf init -s -T codex -p custom -k "your-api-key" \
-  -u "https://api.minimaxi.com/v1" -M "MiniMax-M3"
+npx zcf init -s -T codex -p minimax-cn -k "your-auth-token"
 ```
 
 ### Kimi (Moonshot)
@@ -445,4 +444,3 @@ vim ~/.claude/settings.json
 - [Config Switch](../cli/config-switch.md) - Multi-configuration switch command
 
 > 💡 **Tip**: Using API provider presets can greatly simplify the configuration process. It's recommended to prefer presets, only use custom configuration when necessary. Regularly check provider documentation to get latest configuration information.
-

--- a/src/config/api-providers.ts
+++ b/src/config/api-providers.ts
@@ -223,6 +223,22 @@ export const API_PROVIDER_PRESETS: ApiProviderPreset[] = [
     description: 'MiniMax API Service',
   },
   {
+    id: 'minimax-cn',
+    name: 'MiniMax CN',
+    supportedCodeTools: ['claude-code', 'codex'],
+    claudeCode: {
+      baseUrl: 'https://api.minimaxi.com/anthropic',
+      authType: 'auth_token',
+      defaultModels: ['MiniMax-M3', 'MiniMax-M2.7'],
+    },
+    codex: {
+      baseUrl: 'https://api.minimaxi.com/v1',
+      wireApi: 'responses',
+      defaultModel: 'MiniMax-M3',
+    },
+    description: 'MiniMax China API Service',
+  },
+  {
     id: 'kimi-coding',
     name: 'Kimi Coding',
     supportedCodeTools: ['claude-code'],

--- a/tests/unit/config/api-providers.test.ts
+++ b/tests/unit/config/api-providers.test.ts
@@ -94,6 +94,20 @@ describe('aPI Provider Configuration', () => {
       expect(provider!.codex?.defaultModel).toBe('MiniMax-M3')
     })
 
+    it('minimax-cn provider should have correct regional configuration', () => {
+      const provider = API_PROVIDER_PRESETS.find(p => p.id === 'minimax-cn')
+      expect(provider).toBeDefined()
+      expect(provider!.name).toBe('MiniMax CN')
+      expect(provider!.supportedCodeTools).toContain('claude-code')
+      expect(provider!.supportedCodeTools).toContain('codex')
+      expect(provider!.claudeCode?.baseUrl).toBe('https://api.minimaxi.com/anthropic')
+      expect(provider!.claudeCode?.authType).toBe('auth_token')
+      expect(provider!.claudeCode?.defaultModels).toEqual(['MiniMax-M3', 'MiniMax-M2.7'])
+      expect(provider!.codex?.baseUrl).toBe('https://api.minimaxi.com/v1')
+      expect(provider!.codex?.wireApi).toBe('responses')
+      expect(provider!.codex?.defaultModel).toBe('MiniMax-M3')
+    })
+
     it('bailian-coding provider should use lowercase glm-5 default model', () => {
       const provider = API_PROVIDER_PRESETS.find(p => p.id === 'bailian-coding')
       expect(provider).toBeDefined()


### PR DESCRIPTION
Reason: Make MiniMax China endpoints selectable as a first-class regional preset.

## Summary

- add a `minimax-cn` preset for both supported code tools
- bind the preset to the China OpenAI-compatible and Anthropic-compatible endpoints
- reuse the current default models and document direct preset usage

## Checks

- `pnpm vitest run tests/unit/config/api-providers.test.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/config/api-providers.ts tests/unit/config/api-providers.test.ts`
- `git diff HEAD^ HEAD --check`
