### PR TITLE
docs: fix broken star history chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Thanks to the following authors for promoting this project:
 
 If this project helps you, please give me a ⭐️ Star!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=UfoMiao/zcf&type=Date)](https://star-history.com/#UfoMiao/zcf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=UfoMiao/zcf&type=Date)](https://star-history.dera.page/#UfoMiao/zcf&type=date)
 
 <!-- Badges -->
 

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -196,7 +196,7 @@ Telegramグループに参加して、サポートやディスカッション、
 
 このプロジェクトが役立った場合は、⭐️ Starをお願いします！
 
-[![Star History Chart](https://api.star-history.com/svg?repos=UfoMiao/zcf&type=Date)](https://star-history.com/#UfoMiao/zcf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=UfoMiao/zcf&type=Date)](https://star-history.dera.page/#UfoMiao/zcf&type=date)
 
 <!-- Badges -->
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -197,7 +197,7 @@ PatewayAI 是一家面向重度 AI 开发者、专注官方直连的高品质模
 ## ⭐️ Star 历史
 
 如果这个项目对你有帮助，请给我一个 ⭐️ Star！
-[![Star History Chart](https://api.star-history.com/svg?repos=UfoMiao/zcf&type=Date)](https://star-history.com/#UfoMiao/zcf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=UfoMiao/zcf&type=Date)](https://star-history.dera.page/#UfoMiao/zcf&type=date)
 
 <!-- Badges -->
 


### PR DESCRIPTION
The star history chart on the README is currently broken because the old provider is affected by GitHub stargazer API restrictions. This change updates the chart and its wrapping links in the English, Chinese, and Japanese READMEs to use our working alternative, so the chart renders correctly again.