### PR TITLE
🚀 Release v3.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 3.7.3
+
+### Patch Changes
+
+- ## New Features
+  - Introduce built-in code-tool adapter/registry and migrate Claude Code / Codex command handlers to adapter dispatch
+  - Add MiniMax China (`minimax-cn`) API provider preset
+
+  ## 新功能
+  - 引入内置 code-tool adapter/registry 架构，将 Claude Code / Codex 命令处理迁移为 adapter 分发
+  - 新增 MiniMax 国内版（`minimax-cn`）API 提供商预设
+
+  ## Optimization
+  - Derive Claude/Codex paths, leftover cleanup, and provider contracts from adapter definitions
+  - Align Claude/Codex CLI with main for skip/output-style, illegal `-T` fallback, menu update, and provider import feedback
+
+  ## 优化
+  - 从 adapter 定义派生 Claude/Codex 路径、残留清理与 provider 契约
+  - 对齐 Claude/Codex CLI 与 main 的 skip/output-style、非法 `-T` 回退、菜单更新与 provider 导入反馈
+
+  ## Fixes
+  - Normalize Windows command paths by trimming CRLF-separated `where` results and aligning CCR path handling with pathe
+  - Read CCR installed version from package metadata without executing the CLI, preventing CCR 3.x probes from mutating Codex config
+  - Reject illegal Codex `-o` output styles before writes
+  - Restore `--api-configs` success summary and main-equivalent Claude/Codex CLI behavior
+
+  ## 修复
+  - 规范化 Windows 命令路径：裁剪 CRLF 分隔的 `where` 结果，CCR 路径处理与 pathe 约定对齐
+  - 从包元数据读取已安装 CCR 版本，避免执行 CLI 探测导致 CCR 3.x 改写用户 Codex 配置
+  - 非法 Codex `-o` 输出风格在写入前即拒绝
+  - 恢复 `--api-configs` 成功摘要，以及 Claude/Codex 与 main 等价的 CLI 行为
+
+  ## Documentation
+  - Record code-tool plugin architecture decision (ADR 001)
+  - Add Sublyx sponsor and promote AICodeMirror to the top banner
+  - Refresh GLM provider docs (`glm-cn` for zh-CN, `z-ai` for en/ja) and fix star history chart links
+
+  ## 文档
+  - 记录 code-tool 插件架构决策（ADR 001）
+  - 新增 Sublyx 赞助商，并将 AICodeMirror 提升为顶部横幅
+  - 更新 GLM 提供商文档（zh-CN 使用 glm-cn，en/ja 使用 z-ai），并修复 star history 图表链接
+
 ## 3.7.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zcf",
   "type": "module",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "packageManager": "pnpm@10.17.1",
   "description": "Zero-Config Code Flow - One-click configuration tool for Code Cli",
   "author": {


### PR DESCRIPTION
## Description

Release version v3.7.3 with automated version bump and CHANGELOG update.

This patch covers the built-in code-tool adapter/registry migration, MiniMax China preset, Windows/CCR path and version fixes, and sponsor/docs updates. Please review CHANGELOG.md for the full notes.

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests pass
- [x] Coverage maintained

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

## Release Notes

### New Features / 新功能

- Built-in code-tool adapter/registry; Claude Code / Codex commands dispatch through adapters
- MiniMax China (`minimax-cn`) API provider preset
- 内置 code-tool adapter/registry；Claude Code / Codex 命令改为 adapter 分发
- 新增 MiniMax 国内版（`minimax-cn`）API 提供商预设

### Fixes / 修复

- Normalize Windows command paths; read CCR version from package metadata without executing CLI
- Reject illegal Codex `-o` styles before writes; restore `--api-configs` success summary
- 规范化 Windows 命令路径；从包元数据读取 CCR 版本，避免执行 CLI 改写 Codex 配置
- 非法 Codex `-o` 在写入前拒绝；恢复 `--api-configs` 成功摘要

⚠️ **IMPORTANT**: After merge, GitHub Actions will automatically:
- Create release tag
- Publish to npm
- Generate GitHub Release

Do **not** create or push tags manually.

🤖 Generated by /zcf-release command